### PR TITLE
Add CI for wasm targets using wasm-bindgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -230,6 +230,27 @@ matrix:
       arch: amd64
       env:
         - TARGET=x86_64-apple-darwin
+    
+    # WebAssembly (wasm-bindgen)
+
+    - name: "wasm32-unknown-unknown (node)"
+      os: linux
+      arch: amd64
+      install:
+        - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      script:
+        - wasm-pack test --node crates/core_simd
+    
+    - name: "wasm32-unknown-unknown+simd128 (chrome)"
+      os: linux
+      arch: amd64
+      addons:
+        chrome : stable
+      install:
+        - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      script:
+        - RUSTFLAGS="-C target-feature=+simd128"
+        - wasm-pack test --chrome --headless crates/core_simd
 
 script:
   - rustup target add $TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -233,13 +233,16 @@ matrix:
     
     # WebAssembly (wasm-bindgen)
 
-    - name: "wasm32-unknown-unknown (node)"
+    - name: "wasm32-unknown-unknown (node, firefox, chrome)"
       os: linux
       arch: amd64
+      addons:
+        firefox: latest
+        chrome : stable
       install:
         - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       script:
-        - wasm-pack test --node crates/core_simd
+        - wasm-pack test --node --firefox --chrome --headless crates/core_simd
     
     - name: "wasm32-unknown-unknown+simd128 (chrome)"
       os: linux

--- a/crates/core_simd/Cargo.toml
+++ b/crates/core_simd/Cargo.toml
@@ -8,3 +8,9 @@ repository = "https://github.com/rust-lang/stdsimd"
 keywords = ["core", "simd", "intrinsics"]
 categories = ["hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
+version = "0.2"
+
+[dev-dependencies.wasm-bindgen-test]
+version = "0.3"

--- a/crates/core_simd/tests/ops_impl/float_macros.rs
+++ b/crates/core_simd/tests/ops_impl/float_macros.rs
@@ -5,6 +5,12 @@ macro_rules! float_tests {
             use super::*;
             use helpers::lanewise::*;
 
+            #[cfg(target_arch = "wasm32")]
+            use wasm_bindgen_test::*;
+
+            #[cfg(target_arch = "wasm32")]
+            wasm_bindgen_test_configure!(run_in_browser);
+
             // TODO impl this as an associated fn on vectors
             fn from_slice(slice: &[$scalar]) -> core_simd::$vector {
                 let mut value = core_simd::$vector::default();
@@ -17,6 +23,7 @@ macro_rules! float_tests {
             const B: [$scalar; 16] = [16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31.];
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -25,6 +32,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -34,6 +42,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5.;
@@ -42,6 +51,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_scalar_lhs() {
                 let a = 5.;
                 let b = from_slice(&B);
@@ -50,6 +60,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5.;
@@ -59,6 +70,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -67,6 +79,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -76,6 +89,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5.;
@@ -84,6 +98,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_scalar_lhs() {
                 let a = 5.;
                 let b = from_slice(&B);
@@ -92,6 +107,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5.;
@@ -101,6 +117,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -109,6 +126,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -118,6 +136,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5.;
@@ -126,6 +145,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_scalar_lhs() {
                 let a = 5.;
                 let b = from_slice(&B);
@@ -134,6 +154,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5.;
@@ -143,6 +164,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -151,6 +173,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -160,6 +183,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5.;
@@ -168,6 +192,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_scalar_lhs() {
                 let a = 5.;
                 let b = from_slice(&B);
@@ -176,6 +201,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5.;
@@ -185,6 +211,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -193,6 +220,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -202,6 +230,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5.;
@@ -210,6 +239,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_scalar_lhs() {
                 let a = 5.;
                 let b = from_slice(&B);
@@ -218,6 +248,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5.;
@@ -227,6 +258,7 @@ macro_rules! float_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn neg() {
                 let v = from_slice(&A);
                 let expected = apply_unary_lanewise(v, core::ops::Neg::neg);

--- a/crates/core_simd/tests/ops_impl/int_macros.rs
+++ b/crates/core_simd/tests/ops_impl/int_macros.rs
@@ -5,6 +5,12 @@ macro_rules! int_tests {
             use super::*;
             use helpers::lanewise::*;
 
+            #[cfg(target_arch = "wasm32")]
+            use wasm_bindgen_test::*;
+
+            #[cfg(target_arch = "wasm32")]
+            wasm_bindgen_test_configure!(run_in_browser);
+
             // TODO impl this as an associated fn on vectors
             fn from_slice(slice: &[$scalar]) -> core_simd::$vector {
                 let mut value = core_simd::$vector::default();
@@ -35,6 +41,7 @@ macro_rules! int_tests {
             ];
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -43,6 +50,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -52,6 +60,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -60,6 +69,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -68,6 +78,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -77,6 +88,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -85,6 +97,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -94,6 +107,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -102,6 +116,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -110,6 +125,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -119,6 +135,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -127,6 +144,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -136,6 +154,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -144,6 +163,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -152,6 +172,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -161,6 +182,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -169,6 +191,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -178,6 +201,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -186,6 +210,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -194,6 +219,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -203,6 +229,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -211,6 +238,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -220,6 +248,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -228,6 +257,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -236,6 +266,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -245,6 +276,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -253,6 +285,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -262,6 +295,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -270,6 +304,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -278,6 +313,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -287,6 +323,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -295,6 +332,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -304,6 +342,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -312,6 +351,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -320,6 +360,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -329,6 +370,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -337,6 +379,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -346,6 +389,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -354,6 +398,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -362,6 +407,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -371,6 +417,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn neg() {
                 let v = from_slice(&A);
                 let expected = apply_unary_lanewise(v, core::ops::Neg::neg);
@@ -378,6 +425,7 @@ macro_rules! int_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn not() {
                 let v = from_slice(&A);
                 let expected = apply_unary_lanewise(v, core::ops::Not::not);

--- a/crates/core_simd/tests/ops_impl/mask_macros.rs
+++ b/crates/core_simd/tests/ops_impl/mask_macros.rs
@@ -5,6 +5,12 @@ macro_rules! mask_tests {
             use super::*;
             use helpers::lanewise::*;
 
+            #[cfg(target_arch = "wasm32")]
+            use wasm_bindgen_test::*;
+
+            #[cfg(target_arch = "wasm32")]
+            wasm_bindgen_test_configure!(run_in_browser);
+
             fn from_slice(slice: &[bool]) -> core_simd::$vector {
                 let mut value = core_simd::$vector::default();
                 let value_slice: &mut [_] = value.as_mut();
@@ -41,6 +47,7 @@ macro_rules! mask_tests {
             const UNSET_VECTOR: core_simd::$vector = core_simd::$vector::splat(UNSET_SCALAR);
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -49,6 +56,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -58,6 +66,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_scalar_rhs() {
                 let a = from_slice(&A);
                 let expected = a;
@@ -66,6 +75,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_scalar_lhs() {
                 let a = from_slice(&A);
                 let expected = a;
@@ -74,6 +84,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_assign_scalar() {
                 let mut a = from_slice(&A);
                 let expected = a;
@@ -84,6 +95,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -92,6 +104,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -101,6 +114,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_scalar_rhs() {
                 let a = from_slice(&A);
                 assert_biteq!(a | UNSET_SCALAR, a);
@@ -108,6 +122,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_scalar_lhs() {
                 let a = from_slice(&A);
                 assert_biteq!(UNSET_SCALAR | a, a);
@@ -115,6 +130,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_assign_scalar() {
                 let mut a = from_slice(&A);
                 let expected = a;
@@ -125,6 +141,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -133,6 +150,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -142,6 +160,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_scalar_rhs() {
                 let a = from_slice(&A);
                 let expected = apply_binary_scalar_rhs_lanewise(a, SET_SCALAR, core::ops::BitXor::bitxor);
@@ -150,6 +169,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_scalar_lhs() {
                 let a = from_slice(&A);
                 let expected = apply_binary_scalar_lhs_lanewise(SET_SCALAR, a, core::ops::BitXor::bitxor);
@@ -158,6 +178,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_assign_scalar() {
                 let mut a = from_slice(&A);
                 let expected_unset = a;
@@ -169,6 +190,7 @@ macro_rules! mask_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn not() {
                 let v = from_slice(&A);
                 let expected = apply_unary_lanewise(v, core::ops::Not::not);

--- a/crates/core_simd/tests/ops_impl/uint_macros.rs
+++ b/crates/core_simd/tests/ops_impl/uint_macros.rs
@@ -5,6 +5,12 @@ macro_rules! uint_tests {
             use super::*;
             use helpers::lanewise::*;
 
+            #[cfg(target_arch = "wasm32")]
+            use wasm_bindgen_test::*;
+
+            #[cfg(target_arch = "wasm32")]
+            wasm_bindgen_test_configure!(run_in_browser);
+
             // TODO impl this as an associated fn on vectors
             fn from_slice(slice: &[$scalar]) -> core_simd::$vector {
                 let mut value = core_simd::$vector::default();
@@ -35,6 +41,7 @@ macro_rules! uint_tests {
             ];
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -43,6 +50,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -52,6 +60,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -60,6 +69,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -68,6 +78,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn add_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -77,6 +88,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -85,6 +97,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -94,6 +107,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 1;
@@ -102,6 +116,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_scalar_lhs() {
                 let a = 40;
                 let b = from_slice(&B);
@@ -110,6 +125,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn sub_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 1;
@@ -119,6 +135,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -127,6 +144,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -136,6 +154,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -144,6 +163,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -152,6 +172,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn mul_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -161,6 +182,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -169,6 +191,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -178,6 +201,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -186,6 +210,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -194,6 +219,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn div_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -203,6 +229,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -211,6 +238,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -220,6 +248,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -228,6 +257,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -236,6 +266,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn rem_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -245,6 +276,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -253,6 +285,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -262,6 +295,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -270,6 +304,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -278,6 +313,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitand_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -287,6 +323,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -295,6 +332,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -304,6 +342,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -312,6 +351,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -320,6 +360,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitor_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -329,6 +370,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor() {
                 let a = from_slice(&A);
                 let b = from_slice(&B);
@@ -337,6 +379,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_assign() {
                 let mut a = from_slice(&A);
                 let b = from_slice(&B);
@@ -346,6 +389,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_scalar_rhs() {
                 let a = from_slice(&A);
                 let b = 5;
@@ -354,6 +398,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_scalar_lhs() {
                 let a = 5;
                 let b = from_slice(&B);
@@ -362,6 +407,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn bitxor_assign_scalar() {
                 let mut a = from_slice(&A);
                 let b = 5;
@@ -371,6 +417,7 @@ macro_rules! uint_tests {
             }
 
             #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn not() {
                 let v = from_slice(&A);
                 let expected = apply_unary_lanewise(v, core::ops::Not::not);

--- a/crates/core_simd/webdriver.json
+++ b/crates/core_simd/webdriver.json
@@ -1,0 +1,7 @@
+{
+    "goog:chromeOptions": {
+        "args": [
+            "--enable-features=WebAssemblySimd"
+        ]
+    }
+}


### PR DESCRIPTION
This PR introduces CI for `wasm32-unknown-unknown` along with its `simd128` target feature. The SIMD support is tested through Chrome, only because it seemed easiest to set up with experimental flags.

Adding WebAssembly tests is unfortunately a bit intrusive, we need an extra attribute on every `#[test]`, but it all seems to work!