### PR TITLE
Add build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# stdsimd
+# stdsimd - Rust's standard library portable SIMD API
+
+[![Build Status](https://travis-ci.com/rust-lang/stdsimd.svg?branch=master)](https://travis-ci.com/rust-lang/stdsimd)
 
 Code repository for the [Portable SIMD Project Group](https://github.com/rust-lang/project-portable-simd).
 


### PR DESCRIPTION
Adds a build badge for our Travis CI. Also updates the repo title to follow the same scheme as `stdarch`.