### PR TITLE
Implement abs, to_bits, and from_bits for float vectors

### DIFF
--- a/crates/core_simd/src/macros.rs
+++ b/crates/core_simd/src/macros.rs
@@ -295,8 +295,7 @@ macro_rules! impl_float_vector {
             #[inline]
             pub fn abs(self) -> Self {
                 let no_sign = <$bits_ty>::splat(!0 >> 1);
-                let abs = unsafe { crate::intrinsics::simd_and(self.to_bits(), no_sign) };
-                Self::from_bits(abs)
+                Self::from_bits(self.to_bits() & no_sign)
             }
         }
     };

--- a/crates/core_simd/src/vectors_f32.rs
+++ b/crates/core_simd/src/vectors_f32.rs
@@ -1,23 +1,29 @@
-define_vector! {
+define_float_vector! {
     /// Vector of two `f32` values
     struct f32x2([f32; 2]);
+    bits crate::u32x2;
 }
 
-define_vector! {
+define_float_vector! {
     /// Vector of four `f32` values
     struct f32x4([f32; 4]);
+    bits crate::u32x4;
 }
 
-define_vector! {
+define_float_vector! {
     /// Vector of eight `f32` values
     struct f32x8([f32; 8]);
+    bits crate::u32x8;
 }
 
-define_vector! {
+define_float_vector! {
     /// Vector of 16 `f32` values
     struct f32x16([f32; 16]);
+    bits crate::u32x16;
 }
 
 from_transmute_x86! { unsafe f32x4 => __m128 }
 from_transmute_x86! { unsafe f32x8 => __m256 }
 //from_transmute_x86! { unsafe f32x16 => __m512 }
+
+

--- a/crates/core_simd/src/vectors_f64.rs
+++ b/crates/core_simd/src/vectors_f64.rs
@@ -1,16 +1,19 @@
-define_vector! {
+define_float_vector! {
     /// Vector of two `f64` values
     struct f64x2([f64; 2]);
+    bits crate::u64x2;
 }
 
-define_vector! {
+define_float_vector! {
     /// Vector of four `f64` values
     struct f64x4([f64; 4]);
+    bits crate::u64x4;
 }
 
-define_vector! {
+define_float_vector! {
     /// Vector of eight `f64` values
     struct f64x8([f64; 8]);
+    bits crate::u64x8;
 }
 
 from_transmute_x86! { unsafe f64x2 => __m128d }

--- a/crates/core_simd/tests/ops_impl/float_macros.rs
+++ b/crates/core_simd/tests/ops_impl/float_macros.rs
@@ -19,6 +19,11 @@ macro_rules! float_tests {
                 value
             }
 
+            fn slice_chunks(slice: &[$scalar]) -> impl Iterator<Item = core_simd::$vector> + '_ {
+                let lanes = core::mem::size_of::<core_simd::$vector>() / core::mem::size_of::<$scalar>();
+                slice.chunks_exact(lanes).map(from_slice)
+            }
+
             const A: [$scalar; 16] = [0.,   1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11., 12., 13., 14., 15.];
             const B: [$scalar; 16] = [16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31.];
             const C: [$scalar; 16] = [
@@ -303,9 +308,10 @@ macro_rules! float_tests {
             #[test]
             #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn abs_odd_floats() {
-                let v = from_slice(&C);
-                let expected = apply_unary_lanewise(v, <$scalar>::abs);
-                assert_biteq!(v.abs(), expected);
+                for v in slice_chunks(&C) {
+                    let expected = apply_unary_lanewise(v, <$scalar>::abs);
+                    assert_biteq!(v.abs(), expected);
+                }
             }
         }
     }

--- a/crates/core_simd/tests/ops_impl/float_macros.rs
+++ b/crates/core_simd/tests/ops_impl/float_macros.rs
@@ -21,6 +21,26 @@ macro_rules! float_tests {
 
             const A: [$scalar; 16] = [0.,   1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11., 12., 13., 14., 15.];
             const B: [$scalar; 16] = [16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31.];
+            const C: [$scalar; 16] = [
+                -0.0,
+                0.0,
+                -1.0,
+                1.0,
+                <$scalar>::MIN,
+                <$scalar>::MAX,
+                <$scalar>::INFINITY,
+                -<$scalar>::INFINITY,
+                <$scalar>::MIN_POSITIVE,
+                -<$scalar>::MIN_POSITIVE,
+                <$scalar>::EPSILON,
+                -<$scalar>::EPSILON,
+                0.0 / 0.0,
+                -0.0 / 0.0,
+                // Still not sure if wasm can have weird nans, or I'd check them
+                // too. Until then
+                1.0 / 3.0,
+                -1.0 / 4.0
+            ];
 
             #[test]
             #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -263,6 +283,30 @@ macro_rules! float_tests {
                 let v = from_slice(&A);
                 let expected = apply_unary_lanewise(v, core::ops::Neg::neg);
                 assert_biteq!(-v, expected);
+            }
+
+            #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+            fn abs_negative() {
+                let v = -from_slice(&A);
+                let expected = apply_unary_lanewise(v, <$scalar>::abs);
+                assert_biteq!(v.abs(), expected);
+            }
+
+            #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+            fn abs_positive() {
+                let v = from_slice(&B);
+                let expected = apply_unary_lanewise(v, <$scalar>::abs);
+                assert_biteq!(v.abs(), expected);
+            }
+
+            #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+            fn abs_odd_floats() {
+                let v = from_slice(&C);
+                let expected = apply_unary_lanewise(v, <$scalar>::abs);
+                assert_biteq!(v.abs(), expected);
             }
         }
     }

--- a/crates/core_simd/tests/ops_impl/float_macros.rs
+++ b/crates/core_simd/tests/ops_impl/float_macros.rs
@@ -29,17 +29,16 @@ macro_rules! float_tests {
                 <$scalar>::MIN,
                 <$scalar>::MAX,
                 <$scalar>::INFINITY,
-                -<$scalar>::INFINITY,
+                <$scalar>::NEG_INFINITY,
                 <$scalar>::MIN_POSITIVE,
                 -<$scalar>::MIN_POSITIVE,
                 <$scalar>::EPSILON,
                 -<$scalar>::EPSILON,
-                0.0 / 0.0,
-                -0.0 / 0.0,
-                // Still not sure if wasm can have weird nans, or I'd check them
-                // too. Until then
-                1.0 / 3.0,
-                -1.0 / 4.0
+                <$scalar>::NAN,
+                -<$scalar>::NAN,
+                // TODO: Would be nice to check sNaN...
+                100.0 / 3.0,
+                -100.0 / 3.0,
             ];
 
             #[test]


### PR DESCRIPTION
This started as a PR making neg use simd_xor, but it already does that, so I changed it to one for `abs`. It gets to_bits/from_bits for free, but I can make those non-pub if we want to wait on that, it just was easy.

I'm probably stretching the definition of `ops` for where I put the tests, but it seemed like the alternative was to duplicate a bunch of scaffolding. That said, if you give me clear indication where you'd like it instead I can do that.

Also, is there an easy way to run tests under wasm?