### PR TITLE
Completely overhaul CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,151 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  x86-tests:
+    name: "${{ matrix.target_feature }} on ${{ matrix.target }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-pc-windows-msvc, i686-pc-windows-msvc, i586-pc-windows-msvc, x86_64-unknown-linux-gnu, x86_64-apple-darwin]
+        # `default` means we use the default target config for the target,
+        # `native` means we run with `-Ctarget-cpu=native`, and anything else is
+        # an arg to `-Ctarget-feature`
+        target_feature: [default, native, +sse3, +ssse3, +sse4.1, +sse4.2, +avx, +avx2]
+
+        exclude:
+          # The macos runners seem to only reliably support up to `avx`.
+          - { target: x86_64-apple-darwin, target_feature: +avx2 }
+          # These features are statically known to be present for all 64 bit
+          # macs, and thus are covered by the `default` test
+          - { target: x86_64-apple-darwin, target_feature: +sse3 }
+          - { target: x86_64-apple-darwin, target_feature: +ssse3 }
+          # -Ctarget-cpu=native sounds like bad-news if target != host
+          - { target: i686-pc-windows-msvc, target_feature: native }
+          - { target: i586-pc-windows-msvc, target_feature: native }
+
+        include:
+          # Populate the `matrix.os` field
+          - { target: x86_64-apple-darwin,      os: macos-latest }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
+          - { target: x86_64-pc-windows-msvc,   os: windows-latest }
+          - { target: i686-pc-windows-msvc,     os: windows-latest }
+          - { target: i586-pc-windows-msvc,     os: windows-latest }
+
+          # These are globally available on all the other targets.
+          - { target: i586-pc-windows-msvc, target_feature: +sse, os: windows-latest }
+          - { target: i586-pc-windows-msvc, target_feature: +sse2, os: windows-latest }
+
+          # Annoyingly, the x86_64-unknown-linux-gnu runner *almost* always has
+          # avx512vl, but occasionally doesn't. As a result, we still run that
+          # one under travis.
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust
+        run: |
+          rustup update nightly --no-self-update
+          rustup default nightly
+          rustup target add ${{ matrix.target }}
+
+      - name: Configure RUSTFLAGS
+        shell: bash
+        run: |
+          case "${{ matrix.target_feature }}" in
+            default)
+              ;;
+            native)
+              echo "RUSTFLAGS=-Ctarget-cpu=native" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "RUSTFLAGS=-Ctarget-feature=${{ matrix.target_feature }}" >> $GITHUB_ENV
+              ;;
+          esac
+
+      # Super useful for debugging why a SIGILL occurred.
+      - name: Dump target configuration and support
+        run: |
+          rustc -Vv
+
+          echo "Caveat: not all target features are expected to be logged"
+
+          echo "## Requested target configuration (RUSTFLAGS=$RUSTFLAGS)"
+          rustc --print=cfg --target=${{ matrix.target }} $RUSTFLAGS
+
+          echo "## Supported target configuration for --target=${{ matrix.target }}"
+          rustc --print=cfg --target=${{ matrix.target }} -Ctarget-cpu=native
+
+          echo "## Natively supported target configuration"
+          rustc --print=cfg -Ctarget-cpu=native
+
+      - name: Test (debug)
+        run: cargo test --verbose --target=${{ matrix.target }}
+
+      - name: Test (release)
+        run: cargo test --verbose --target=${{ matrix.target }} --release
+
+  cross-tests:
+    name: "${{ matrix.target }} (via cross)"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # TODO: Sadly, we cant configure target-feature in a meaningful way
+      # because `cross` doesn't tell qemu to enable any non-default cpu
+      # features, nor does it give us a way to do so.
+      #
+      # Ultimately, we'd like to do something like [rust-lang/stdarch][stdarch].
+      # This is a lot more complex... but in practice it's likely that we can just
+      # snarf the docker config from around [here][1000-dockerfiles].
+      #
+      # [stdarch]: https://github.com/rust-lang/stdarch/blob/a5db4eaf/.github/workflows/main.yml#L67
+      # [1000-dockerfiles]: https://github.com/rust-lang/stdarch/tree/a5db4eaf/ci/docker
+
+      matrix:
+        target:
+          - i586-unknown-linux-gnu
+          # 32-bit arm has a few idiosyncracies like having subnormal flushing
+          # to zero on by default. Ideally we'd set
+          - armv7-unknown-linux-gnueabihf
+          # Note: The issue above means neither of these mips targets will use
+          # MSA (mips simd) but MIPS uses a nonstandard binary representation
+          # for NaNs which makes it worth testing on despite that.
+          - mips-unknown-linux-gnu
+          - mips64-unknown-linux-gnuabi64
+          - riscv64gc-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust
+        run: |
+          rustup update nightly --no-self-update
+          rustup default nightly
+          rustup target add ${{ matrix.target }}
+          rustup component add rust-src
+
+      - name: Install Cross
+        # Equivalent to `cargo install cross`, but downloading a prebuilt
+        # binary. Ideally we wouldn't hardcode a version, but the version number
+        # being part of the tarball means we can't just use the download/latest
+        # URL :(
+        run: |
+          CROSS_URL=https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz
+          mkdir -p "$HOME/.bin"
+          curl -sfSL --retry-delay 10 --retry 5 "${CROSS_URL}" | tar zxf - -C "$HOME/.bin"
+          echo "$HOME/.bin" >> $GITHUB_PATH
+
+      - name: Test (debug)
+        run: cross test --verbose --target=${{ matrix.target }}
+
+      - name: Test (release)
+        run: cross test --verbose --target=${{ matrix.target }} --release
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,257 +5,74 @@ rust:
 matrix:
   fast_finish: true
   include:
-    # Linux (x86_64)
-
-    - name: "x86_64-unknown-linux-gnu"
+    # Linux (aarch64)
+    - name: "aarch64-unknown-linux-gnu (neon)"
       os: linux
-      arch: amd64
-      env:
-        - TARGET=x86_64-unknown-linux-gnu
+      arch: arm64
 
-    - name: "x86_64-unknown-linux-gnu+sse"
+    - name: "aarch64-unknown-linux-gnu (neon, sve)"
       os: linux
-      arch: amd64
-      env:
-        - TARGET=x86_64-unknown-linux-gnu
-        - TARGET_FEATURE=sse
+      arch: arm64
+      env: RUSTFLAGS=-Ctarget-feature=+sve
 
-    - name: "x86_64-unknown-linux-gnu+sse2"
+    - name: "aarch64-unknown-linux-gnu (native, see log for cfg)"
       os: linux
-      arch: amd64
-      env:
-        - TARGET=x86_64-unknown-linux-gnu
-        - TARGET_FEATURE=sse2
+      arch: arm64
+      env: RUSTFLAGS=-Ctarget-cpu=native
 
-    - name: "x86_64-unknown-linux-gnu+sse3"
+    # Linux (powerpc64le)
+    - name: "powerpc64le-unknown-linux-gnu (altivec, vsx, power8-*)"
       os: linux
-      arch: amd64
-      env:
-        - TARGET=x86_64-unknown-linux-gnu
-        - TARGET_FEATURE=sse3
+      arch: ppc64le
 
-    - name: "x86_64-unknown-linux-gnu+sse4.1"
+    - name: "powerpc64le-unknown-linux-gnu (native, see log for cfg)"
       os: linux
-      arch: amd64
-      env:
-        - TARGET=x86_64-unknown-linux-gnu
-        - TARGET_FEATURE=sse4.1
+      arch: ppc64le
+      env: RUSTFLAGS=-Ctarget-cpu=native
 
-    - name: "x86_64-unknown-linux-gnu+sse4.2"
-      os: linux
-      arch: amd64
-      env:
-        - TARGET=x86_64-unknown-linux-gnu
-        - TARGET_FEATURE=sse4.2
-
-    - name: "x86_64-unknown-linux-gnu+avx"
-      os: linux
-      arch: amd64
-      env:
-        - TARGET=x86_64-unknown-linux-gnu
-        - TARGET_FEATURE=avx
-
-    - name: "x86_64-unknown-linux-gnu+avx2"
-      os: linux
-      arch: amd64
-      env:
-        - TARGET=x86_64-unknown-linux-gnu
-        - TARGET_FEATURE=avx2
-
+    # Linux (x86_64) (for AVX512, which sadly seems to only *usually* be present
+    # on the github actions linux runner...)
     - name: "x86_64-unknown-linux-gnu+avx512vl"
       os: linux
       arch: amd64
-      env:
-        - TARGET=x86_64-unknown-linux-gnu
-        - TARGET_FEATURE=avx512vl
+      env: RUSTFLAGS=-Ctarget-feature=+avx512vl
 
-    # Linux (aarch64)
-
-    - name: "aarch64-unknown-linux-gnu"
-      os: linux
-      arch: arm64
-      env:
-        - TARGET=aarch64-unknown-linux-gnu
-
-    - name: "aarch64-unknown-linux-gnu+neon"
-      os: linux
-      arch: arm64
-      env:
-        - TARGET=aarch64-unknown-linux-gnu
-        - TARGET_FEATURE=neon
-
-    - name: "aarch64-unknown-linux-gnu+sve"
-      os: linux
-      arch: arm64
-      env:
-        - TARGET=aarch64-unknown-linux-gnu
-        - TARGET_FEATURE=sve
-
-    # Linux (powerpc64)
-
-    - name: "powerpc64le-unknown-linux-gnu"
-      os: linux
-      arch: ppc64le
-      env:
-        - TARGET=powerpc64le-unknown-linux-gnu
-
-    - name: "powerpc64le-unknown-linux-gnu+vsx"
-      os: linux
-      arch: ppc64le
-      env:
-        - TARGET=powerpc64le-unknown-linux-gnu
-        - TARGET_FEATURE=vsx
-
-    # Windows (x86_64)
-
-    - name: "x86_64-pc-windows-msvc"
-      os: windows
-      arch: amd64
-      env: TARGET=x86_64-pc-windows-msvc
-    
-    # Windows (i686)
-
-    - name: "i686-pc-windows-msvc"
-      os: windows
-      env: TARGET=i686-pc-windows-msvc
-
-    - name: "i686-pc-windows-msvc+sse"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i686-pc-windows-msvc
-        - TARGET_FEATURE=sse
-
-    - name: "i686-pc-windows-msvc+sse2"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i686-pc-windows-msvc
-        - TARGET_FEATURE=sse2
-
-    - name: "i686-pc-windows-msvc+sse3"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i686-pc-windows-msvc
-        - TARGET_FEATURE=sse3
-
-    - name: "i686-pc-windows-msvc+sse4.1"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i686-pc-windows-msvc
-        - TARGET_FEATURE=sse4.1
-
-    - name: "i686-pc-windows-msvc+sse4.2"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i686-pc-windows-msvc
-        - TARGET_FEATURE=sse4.2
-
-    - name: "i686-pc-windows-msvc+avx"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i686-pc-windows-msvc
-        - TARGET_FEATURE=avx
-
-    - name: "i686-pc-windows-msvc+avx2"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i686-pc-windows-msvc
-        - TARGET_FEATURE=avx2
-
-    # Windows (i586)
-
-    - name: "i586-pc-windows-msvc"
-      os: windows
-      env: TARGET=i586-pc-windows-msvc
-
-    - name: "i586-pc-windows-msvc+sse"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i586-pc-windows-msvc
-        - TARGET_FEATURE=sse
-
-    - name: "i586-pc-windows-msvc+sse2"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i586-pc-windows-msvc
-        - TARGET_FEATURE=sse2
-
-    - name: "i586-pc-windows-msvc+sse3"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i586-pc-windows-msvc
-        - TARGET_FEATURE=sse3
-
-    - name: "i586-pc-windows-msvc+sse4.1"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i586-pc-windows-msvc
-        - TARGET_FEATURE=sse4.1
-
-    - name: "i586-pc-windows-msvc+sse4.2"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i586-pc-windows-msvc
-        - TARGET_FEATURE=sse4.2
-
-    - name: "i586-pc-windows-msvc+avx"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i586-pc-windows-msvc
-        - TARGET_FEATURE=avx
-
-    - name: "i586-pc-windows-msvc+avx2"
-      os: windows
-      arch: amd64
-      env:
-        - TARGET=i586-pc-windows-msvc
-        - TARGET_FEATURE=avx2
-
-    # OSX (x86_64)
-
-    - name: "x86_64-apple-darwin"
-      os: osx
-      arch: amd64
-      env:
-        - TARGET=x86_64-apple-darwin
-    
     # WebAssembly (wasm-bindgen)
-
     - name: "wasm32-unknown-unknown (node, firefox, chrome)"
       os: linux
       arch: amd64
       addons:
         firefox: latest
-        chrome : stable
+        chrome: stable
       install:
         - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       script:
         - wasm-pack test --node --firefox --chrome --headless crates/core_simd
-    
+        - wasm-pack test --node --firefox --chrome --headless crates/core_simd --release
+
     - name: "wasm32-unknown-unknown+simd128 (chrome)"
       os: linux
       arch: amd64
       addons:
-        chrome : stable
+        chrome: stable
       install:
         - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       script:
-        - RUSTFLAGS="-C target-feature=+simd128"
+        - export RUSTFLAGS="-C target-feature=+simd128"
         - wasm-pack test --chrome --headless crates/core_simd
+        - wasm-pack test --chrome --headless crates/core_simd --release
 
 script:
-  - rustup target add $TARGET
-  - if [ -n "$TARGET_FEATURE" ]; then RUSTFLAGS="-C target-feature=+$TARGET_FEATURE"; fi
-  - cargo test -v --target $TARGET
+  - echo "## Requested target configuration (RUSTFLAGS=$RUSTFLAGS)"
+  - rustc --print=cfg $RUSTFLAGS
+
+  - echo "## Supported target configuration"
+  - rustc --print=cfg -Ctarget-cpu=native
+
+  - echo "\n---\n"
+
+  - echo "## Running tests (debug)"
+  - cargo test -v
+
+  - echo "## Running tests (release)"
+  - cargo test -v --release


### PR DESCRIPTION
This patch more or less rewrites most of how we do CI. I mentioned I was going to fix some issues with the current CI and add cross support... and, well, here we are.

The main stuff it does is:

- Fixes the cases where target features were incorrectly specified or equivalent feature sets were specified redundantly.
- Moves x86-family target testing to github actions (better `matrix`, follows with what most of `rust-lang/*` does, more functionality for less code, ...).
- Add support for testing several architectures under `cross` (including some problematic ones like arm32 and mips).
- Ensure we run tests both as debug and release (I have a forthcoming patch with a new test and fix that is only caught with this).
- It's also more well-commented, although some of those are (well-explained, to be fair) TODOs.

We still use travis for aarch64/ppc64le tests (these have native runners), x86_64 linux AVX512 since while most of the time GHA's linux runners have avx512vl, it failed on me once, and the WASM tests, since I didn't feel like figuring that out right now 😅.

One dowside with the current status is that the x86 tests in github actions spawn a lot of jobs (each target_feature * each target), which all show up as rows here. This is equivalent to what the travis code did, and makes identifying what failed easy, but it would be easy for me to change this (although when I tried this before it was a lot slower due to lost parallelism).

It's also worth noting that IMO the `cross` usage a stepping stone to setting up CI like stdarch does (lots of docker), but it does make it a lot eaier to be confident I haven't e.g. messed up something about MIPs or w/e. Anyway, one thing at a time.

I think you cannot yet see the CI results directly in the PR prior to merging (might be wrong). I have a test PR against my fork that you can see them passing, though: https://github.com/thomcc/stdsimd/pull/1. (Well, travis will finish running someday at least, but it hasn't been spotty at all)
