### PR TITLE
Use xor to implement Neg::neg for floats

### DIFF
--- a/crates/core_simd/src/ops.rs
+++ b/crates/core_simd/src/ops.rs
@@ -212,7 +212,18 @@ macro_rules! impl_op {
             impl core::ops::Neg for $type {
                 type Output = Self;
                 fn neg(self) -> Self::Output {
-                    <$type>::splat(-<$scalar>::default()) - self
+                    <$type>::splat(0) - self
+                }
+            }
+        }
+    };
+
+    { impl Neg for $type:ty, $scalar:ty, @float } => {
+        impl_ref_ops! {
+            impl core::ops::Neg for $type {
+                type Output = Self;
+                fn neg(self) -> Self::Output {
+                    Self::from_bits(<$type>::splat(-0.0).to_bits() ^ self.to_bits())
                 }
             }
         }
@@ -310,7 +321,7 @@ macro_rules! impl_float_ops {
                 impl_op! { impl Mul for $vector, $scalar }
                 impl_op! { impl Div for $vector, $scalar }
                 impl_op! { impl Rem for $vector, $scalar }
-                impl_op! { impl Neg for $vector, $scalar }
+                impl_op! { impl Neg for $vector, $scalar, @float }
                 impl_op! { impl Index for $vector, $scalar }
             )*
         )*

--- a/crates/core_simd/src/ops.rs
+++ b/crates/core_simd/src/ops.rs
@@ -223,6 +223,8 @@ macro_rules! impl_op {
             impl core::ops::Neg for $type {
                 type Output = Self;
                 fn neg(self) -> Self::Output {
+                    // FIXME: Replace this with fneg intrinsic once available.
+                    // https://github.com/rust-lang/stdsimd/issues/32
                     Self::from_bits(<$type>::splat(-0.0).to_bits() ^ self.to_bits())
                 }
             }

--- a/crates/core_simd/tests/ops_impl/float_macros.rs
+++ b/crates/core_simd/tests/ops_impl/float_macros.rs
@@ -291,6 +291,15 @@ macro_rules! float_tests {
 
             #[test]
             #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+            fn neg_odd_floats() {
+                for v in slice_chunks(&C) {
+                    let expected = apply_unary_lanewise(v, core::ops::Neg::neg);
+                    assert_biteq!(-v, expected);
+                }
+            }
+
+            #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             fn abs_negative() {
                 let v = -from_slice(&A);
                 let expected = apply_unary_lanewise(v, <$scalar>::abs);


### PR DESCRIPTION
This returns the correct on all architectures, and avoids raising float exceptions, canonicalizing values, and setting status registers no matter the argument in both debug/release builds. This is required by IEEE-754, see<sup>1</sup>

Note that without the impl change, I believe we'd need to bring in the CI changes from #30 to actually trigger a failure, but https://github.com/thomcc/stdsimd/runs/1220021695 has examples of the failure cases (don't look at the ones that failed to build, I'm referring to the ones that failed the test this adds).

Ultimately though, this is a placeholder until some sort of neg intrinsic is provided by rustc, as while this is fairly optimal on Intel, that is not true for ARM. That said, this fixes the issue with the old implementation, even if it's not optimal everywhere.

---

1: From IEEE754-2019 section 5.5.1 "Sign bit operations"

> `negate(x)` copies a floating-point operand x to a destination in the same format, reversing the sign bit. negate(x) is not the same as subtraction(0, x)

It also says (when introducing negate/abs/copysign) a few lines earlier:

> The operations treat floating-point numbers and NaNs alike, and signal no exception. These operations may propagate non-canonical encodings.

Note that subtraction/multiplication would violate these requirements.