### PR TITLE
min_const_generics ride the train to stable

### DIFF
--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(repr_simd, platform_intrinsics, link_llvm_intrinsics, simd_ffi, min_const_generics)]
+#![feature(repr_simd, platform_intrinsics, link_llvm_intrinsics, simd_ffi)]
 #![warn(missing_docs)]
 //! Portable SIMD module.
 


### PR DESCRIPTION
This warning keeps bugging me and these are heading to stable soon, so it's probably time to remove this qualifier. That's all.