### PR TITLE
Add a blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: Create a blank issue.
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,5 @@
+# This only controls whether a tiny, hard-to-find "open a blank issue" link appears at the end of
+# the template list.
 blank_issues_enabled: true
 contact_links:
   - name: Intrinsic Support


### PR DESCRIPTION
Setting this in config.yml only enables the appearance of a tiny link
on GitHub that is hard to see and find. This template adds a "blank issue"
link that is as equally visible as the rest of the template options.

With thanks to @thomcc for the recommendation.