### PR TITLE
Limit all types to 64 lanes

### DIFF
--- a/crates/core_simd/src/fmt.rs
+++ b/crates/core_simd/src/fmt.rs
@@ -33,7 +33,10 @@ macro_rules! impl_fmt_trait {
     { $($type:ident => $(($trait:ident, $format:ident)),*;)* } => {
         $( // repeat type
             $( // repeat trait
-                impl<const LANES: usize> core::fmt::$trait for crate::$type<LANES> {
+                impl<const LANES: usize> core::fmt::$trait for crate::$type<LANES>
+                where
+                    Self: crate::LanesAtMost64,
+                {
                     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                         $format(self.as_ref(), f)
                     }

--- a/crates/core_simd/src/lanes_at_most_64.rs
+++ b/crates/core_simd/src/lanes_at_most_64.rs
@@ -1,0 +1,35 @@
+/// Implemented for bitmask sizes that are supported by the implementation.
+pub trait LanesAtMost64 {}
+
+macro_rules! impl_for {
+    { $name:ident } => {
+        impl LanesAtMost64 for $name<1> {}
+        impl LanesAtMost64 for $name<2> {}
+        impl LanesAtMost64 for $name<4> {}
+        impl LanesAtMost64 for $name<8> {}
+        impl LanesAtMost64 for $name<16> {}
+        impl LanesAtMost64 for $name<32> {}
+        impl LanesAtMost64 for $name<64> {}
+    }
+}
+
+use crate::*;
+
+impl_for! { SimdU8 }
+impl_for! { SimdU16 }
+impl_for! { SimdU32 }
+impl_for! { SimdU64 }
+impl_for! { SimdU128 }
+impl_for! { SimdUsize }
+
+impl_for! { SimdI8 }
+impl_for! { SimdI16 }
+impl_for! { SimdI32 }
+impl_for! { SimdI64 }
+impl_for! { SimdI128 }
+impl_for! { SimdIsize }
+
+impl_for! { SimdF32 }
+impl_for! { SimdF64 }
+
+impl_for! { BitMask }

--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -15,7 +15,7 @@ mod ops;
 mod round;
 
 mod lanes_at_most_64;
-pub use lanes_at_most_64::*;
+pub use lanes_at_most_64::LanesAtMost64;
 
 mod masks;
 pub use masks::*;

--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -14,6 +14,9 @@ mod intrinsics;
 mod ops;
 mod round;
 
+mod lanes_at_most_64;
+pub use lanes_at_most_64::*;
+
 mod masks;
 pub use masks::*;
 

--- a/crates/core_simd/src/macros.rs
+++ b/crates/core_simd/src/macros.rs
@@ -29,7 +29,7 @@ macro_rules! from_transmute_x86 {
 /// Implements common traits on the specified vector `$name`, holding multiple `$lanes` of `$type`.
 macro_rules! impl_vector {
     { $name:ident, $type:ty } => {
-        impl<const LANES: usize> $name<LANES> {
+        impl<const LANES: usize> $name<LANES> where Self: crate::LanesAtMost64 {
             /// Construct a SIMD vector by setting all lanes to the given value.
             pub const fn splat(value: $type) -> Self {
                 Self([value; LANES])
@@ -72,23 +72,23 @@ macro_rules! impl_vector {
             }
         }
 
-        impl<const LANES: usize> Copy for $name<LANES> {}
+        impl<const LANES: usize> Copy for $name<LANES> where Self: crate::LanesAtMost64 {}
 
-        impl<const LANES: usize> Clone for $name<LANES> {
+        impl<const LANES: usize> Clone for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn clone(&self) -> Self {
                 *self
             }
         }
 
-        impl<const LANES: usize> Default for $name<LANES> {
+        impl<const LANES: usize> Default for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn default() -> Self {
                 Self::splat(<$type>::default())
             }
         }
 
-        impl<const LANES: usize> PartialEq for $name<LANES> {
+        impl<const LANES: usize> PartialEq for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
                 // TODO use SIMD equality
@@ -96,7 +96,7 @@ macro_rules! impl_vector {
             }
         }
 
-        impl<const LANES: usize> PartialOrd for $name<LANES> {
+        impl<const LANES: usize> PartialOrd for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
                 // TODO use SIMD equalitya
@@ -105,14 +105,14 @@ macro_rules! impl_vector {
         }
 
         // array references
-        impl<const LANES: usize> AsRef<[$type; LANES]> for $name<LANES> {
+        impl<const LANES: usize> AsRef<[$type; LANES]> for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn as_ref(&self) -> &[$type; LANES] {
                 &self.0
             }
         }
 
-        impl<const LANES: usize> AsMut<[$type; LANES]> for $name<LANES> {
+        impl<const LANES: usize> AsMut<[$type; LANES]> for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn as_mut(&mut self) -> &mut [$type; LANES] {
                 &mut self.0
@@ -120,14 +120,14 @@ macro_rules! impl_vector {
         }
 
         // slice references
-        impl<const LANES: usize> AsRef<[$type]> for $name<LANES> {
+        impl<const LANES: usize> AsRef<[$type]> for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn as_ref(&self) -> &[$type] {
                 &self.0
             }
         }
 
-        impl<const LANES: usize> AsMut<[$type]> for $name<LANES> {
+        impl<const LANES: usize> AsMut<[$type]> for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn as_mut(&mut self) -> &mut [$type] {
                 &mut self.0
@@ -135,14 +135,14 @@ macro_rules! impl_vector {
         }
 
         // vector/array conversion
-        impl<const LANES: usize> From<[$type; LANES]> for $name<LANES> {
+        impl<const LANES: usize> From<[$type; LANES]> for $name<LANES> where Self: crate::LanesAtMost64 {
             fn from(array: [$type; LANES]) -> Self {
                 Self(array)
             }
         }
 
         // splat
-        impl<const LANES: usize> From<$type> for $name<LANES> {
+        impl<const LANES: usize> From<$type> for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn from(value: $type) -> Self {
                 Self::splat(value)
@@ -158,9 +158,9 @@ macro_rules! impl_integer_vector {
     { $name:ident, $type:ty } => {
         impl_vector! { $name, $type }
 
-        impl<const LANES: usize> Eq for $name<LANES> {}
+        impl<const LANES: usize> Eq for $name<LANES> where Self: crate::LanesAtMost64 {}
 
-        impl<const LANES: usize> Ord for $name<LANES> {
+        impl<const LANES: usize> Ord for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn cmp(&self, other: &Self) -> core::cmp::Ordering {
                 // TODO use SIMD cmp
@@ -168,7 +168,7 @@ macro_rules! impl_integer_vector {
             }
         }
 
-        impl<const LANES: usize> core::hash::Hash for $name<LANES> {
+        impl<const LANES: usize> core::hash::Hash for $name<LANES> where Self: crate::LanesAtMost64 {
             #[inline]
             fn hash<H>(&self, state: &mut H)
             where
@@ -187,7 +187,11 @@ macro_rules! impl_float_vector {
     { $name:ident, $type:ty, $bits_ty:ident } => {
         impl_vector! { $name, $type }
 
-        impl<const LANES: usize> $name<LANES> {
+        impl<const LANES: usize> $name<LANES>
+        where
+            Self: crate::LanesAtMost64,
+            crate::$bits_ty<LANES>: crate::LanesAtMost64,
+        {
             /// Raw transmutation to an unsigned integer vector type with the
             /// same size and number of lanes.
             #[inline]

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -1,12 +1,4 @@
-/// Implemented for bitmask sizes that are supported by the implementation.
-pub trait LanesAtMost64 {}
-impl LanesAtMost64 for BitMask<1> {}
-impl LanesAtMost64 for BitMask<2> {}
-impl LanesAtMost64 for BitMask<4> {}
-impl LanesAtMost64 for BitMask<8> {}
-impl LanesAtMost64 for BitMask<16> {}
-impl LanesAtMost64 for BitMask<32> {}
-impl LanesAtMost64 for BitMask<64> {}
+use crate::LanesAtMost64;
 
 /// A mask where each lane is represented by a single bit.
 #[derive(Copy, Clone, Debug)]

--- a/crates/core_simd/src/masks/full_masks.rs
+++ b/crates/core_simd/src/masks/full_masks.rs
@@ -16,11 +16,31 @@ impl core::fmt::Display for TryFromMaskError {
 macro_rules! define_mask {
     { $(#[$attr:meta])* struct $name:ident<const $lanes:ident: usize>($type:ty); } => {
         $(#[$attr])*
-        #[derive(Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
+        #[derive(Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
         #[repr(transparent)]
-        pub struct $name<const $lanes: usize>($type);
+        pub struct $name<const $lanes: usize>($type)
+        where
+            $type: crate::LanesAtMost64;
 
-        impl<const $lanes: usize> $name<$lanes> {
+        impl<const LANES: usize> Copy for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {}
+
+        impl<const LANES: usize> Clone for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
+            #[inline]
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<const $lanes: usize> $name<$lanes>
+        where
+            $type: crate::LanesAtMost64,
+        {
             /// Construct a mask by setting all lanes to the given value.
             pub fn splat(value: bool) -> Self {
                 Self(<$type>::splat(
@@ -57,13 +77,19 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const $lanes: usize> core::convert::From<bool> for $name<$lanes> {
+        impl<const $lanes: usize> core::convert::From<bool> for $name<$lanes>
+        where
+            $type: crate::LanesAtMost64,
+        {
             fn from(value: bool) -> Self {
                 Self::splat(value)
             }
         }
 
-        impl<const $lanes: usize> core::convert::TryFrom<$type> for $name<$lanes> {
+        impl<const $lanes: usize> core::convert::TryFrom<$type> for $name<$lanes>
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Error = TryFromMaskError;
             fn try_from(value: $type) -> Result<Self, Self::Error> {
                 if value.as_slice().iter().all(|x| *x == 0 || *x == -1) {
@@ -74,7 +100,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const $lanes: usize> core::convert::From<$name<$lanes>> for $type {
+        impl<const $lanes: usize> core::convert::From<$name<$lanes>> for $type
+        where
+            $type: crate::LanesAtMost64,
+        {
             fn from(value: $name<$lanes>) -> Self {
                 value.0
             }
@@ -82,6 +111,7 @@ macro_rules! define_mask {
 
         impl<const $lanes: usize> core::convert::From<crate::BitMask<$lanes>> for $name<$lanes>
         where
+            $type: crate::LanesAtMost64,
             crate::BitMask<$lanes>: crate::LanesAtMost64,
         {
             fn from(value: crate::BitMask<$lanes>) -> Self {
@@ -96,6 +126,7 @@ macro_rules! define_mask {
 
         impl<const $lanes: usize> core::convert::From<$name<$lanes>> for crate::BitMask<$lanes>
         where
+            $type: crate::LanesAtMost64,
             crate::BitMask<$lanes>: crate::LanesAtMost64,
         {
             fn from(value: $name<$lanes>) -> Self {
@@ -108,7 +139,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const $lanes: usize> core::fmt::Debug for $name<$lanes> {
+        impl<const $lanes: usize> core::fmt::Debug for $name<$lanes>
+        where
+            $type: crate::LanesAtMost64,
+        {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 f.debug_list()
                     .entries((0..LANES).map(|lane| self.test(lane)))
@@ -116,31 +150,46 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const $lanes: usize> core::fmt::Binary for $name<$lanes> {
+        impl<const $lanes: usize> core::fmt::Binary for $name<$lanes>
+        where
+            $type: crate::LanesAtMost64,
+        {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 core::fmt::Binary::fmt(&self.0, f)
             }
         }
 
-        impl<const $lanes: usize> core::fmt::Octal for $name<$lanes> {
+        impl<const $lanes: usize> core::fmt::Octal for $name<$lanes>
+        where
+            $type: crate::LanesAtMost64,
+        {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 core::fmt::Octal::fmt(&self.0, f)
             }
         }
 
-        impl<const $lanes: usize> core::fmt::LowerHex for $name<$lanes> {
+        impl<const $lanes: usize> core::fmt::LowerHex for $name<$lanes>
+        where
+            $type: crate::LanesAtMost64,
+        {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 core::fmt::LowerHex::fmt(&self.0, f)
             }
         }
 
-        impl<const $lanes: usize> core::fmt::UpperHex for $name<$lanes> {
+        impl<const $lanes: usize> core::fmt::UpperHex for $name<$lanes>
+        where
+            $type: crate::LanesAtMost64,
+        {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 core::fmt::UpperHex::fmt(&self.0, f)
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAnd for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitAnd for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitand(self, rhs: Self) -> Self {
@@ -148,7 +197,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAnd<bool> for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitAnd<bool> for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitand(self, rhs: bool) -> Self {
@@ -156,7 +208,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAnd<$name<LANES>> for bool {
+        impl<const LANES: usize> core::ops::BitAnd<$name<LANES>> for bool
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = $name<LANES>;
             #[inline]
             fn bitand(self, rhs: $name<LANES>) -> $name<LANES> {
@@ -164,7 +219,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOr for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitOr for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitor(self, rhs: Self) -> Self {
@@ -172,7 +230,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOr<bool> for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitOr<bool> for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitor(self, rhs: bool) -> Self {
@@ -180,7 +241,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOr<$name<LANES>> for bool {
+        impl<const LANES: usize> core::ops::BitOr<$name<LANES>> for bool
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = $name<LANES>;
             #[inline]
             fn bitor(self, rhs: $name<LANES>) -> $name<LANES> {
@@ -188,7 +252,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXor for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitXor for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitxor(self, rhs: Self) -> Self::Output {
@@ -196,7 +263,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXor<bool> for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitXor<bool> for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitxor(self, rhs: bool) -> Self::Output {
@@ -204,7 +274,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXor<$name<LANES>> for bool {
+        impl<const LANES: usize> core::ops::BitXor<$name<LANES>> for bool
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = $name<LANES>;
             #[inline]
             fn bitxor(self, rhs: $name<LANES>) -> Self::Output {
@@ -212,7 +285,10 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::Not for $name<LANES> {
+        impl<const LANES: usize> core::ops::Not for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             type Output = $name<LANES>;
             #[inline]
             fn not(self) -> Self::Output {
@@ -220,42 +296,60 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAndAssign for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitAndAssign for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             #[inline]
             fn bitand_assign(&mut self, rhs: Self) {
                 self.0 &= rhs.0;
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAndAssign<bool> for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitAndAssign<bool> for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             #[inline]
             fn bitand_assign(&mut self, rhs: bool) {
                 *self &= Self::splat(rhs);
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOrAssign for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitOrAssign for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             #[inline]
             fn bitor_assign(&mut self, rhs: Self) {
                 self.0 |= rhs.0;
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOrAssign<bool> for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitOrAssign<bool> for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             #[inline]
             fn bitor_assign(&mut self, rhs: bool) {
                 *self |= Self::splat(rhs);
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXorAssign for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitXorAssign for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             #[inline]
             fn bitxor_assign(&mut self, rhs: Self) {
                 self.0 ^= rhs.0;
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXorAssign<bool> for $name<LANES> {
+        impl<const LANES: usize> core::ops::BitXorAssign<bool> for $name<LANES>
+        where
+            $type: crate::LanesAtMost64,
+        {
             #[inline]
             fn bitxor_assign(&mut self, rhs: bool) {
                 *self ^= Self::splat(rhs);
@@ -291,11 +385,11 @@ define_mask! {
 define_mask! {
     /// A mask equivalent to [SimdI128](crate::SimdI128), where all bits in the lane must be either set
     /// or unset.
-    struct SimdMask128<const LANES: usize>(crate::SimdI64<LANES>);
+    struct SimdMask128<const LANES: usize>(crate::SimdI128<LANES>);
 }
 
 define_mask! {
     /// A mask equivalent to [SimdIsize](crate::SimdIsize), where all bits in the lane must be either set
     /// or unset.
-    struct SimdMaskSize<const LANES: usize>(crate::SimdI64<LANES>);
+    struct SimdMaskSize<const LANES: usize>(crate::SimdIsize<LANES>);
 }

--- a/crates/core_simd/src/masks/mod.rs
+++ b/crates/core_simd/src/masks/mod.rs
@@ -7,16 +7,22 @@ pub use full_masks::*;
 mod bitmask;
 pub use bitmask::*;
 
+use crate::LanesAtMost64;
+
 macro_rules! define_opaque_mask {
     {
         $(#[$attr:meta])*
         struct $name:ident<const $lanes:ident: usize>($inner_ty:ty);
+        @bits $bits_ty:ty
     } => {
         $(#[$attr])*
         #[allow(non_camel_case_types)]
-        pub struct $name<const $lanes: usize>($inner_ty) where BitMask<LANES>: LanesAtMost64;
+        pub struct $name<const $lanes: usize>($inner_ty) where $bits_ty: LanesAtMost64;
 
-        impl<const $lanes: usize> $name<$lanes> where BitMask<$lanes>: LanesAtMost64 {
+        impl<const $lanes: usize> $name<$lanes>
+        where
+            $bits_ty: LanesAtMost64
+        {
             /// Construct a mask by setting all lanes to the given value.
             pub fn splat(value: bool) -> Self {
                 Self(<$inner_ty>::splat(value))
@@ -43,6 +49,7 @@ macro_rules! define_opaque_mask {
 
         impl<const $lanes: usize> From<BitMask<$lanes>> for $name<$lanes>
         where
+            $bits_ty: LanesAtMost64,
             BitMask<$lanes>: LanesAtMost64,
         {
             fn from(value: BitMask<$lanes>) -> Self {
@@ -52,6 +59,7 @@ macro_rules! define_opaque_mask {
 
         impl<const $lanes: usize> From<$name<$lanes>> for crate::BitMask<$lanes>
         where
+            $bits_ty: LanesAtMost64,
             BitMask<$lanes>: LanesAtMost64,
         {
             fn from(value: $name<$lanes>) -> Self {
@@ -61,7 +69,7 @@ macro_rules! define_opaque_mask {
 
         impl<const $lanes: usize> From<$inner_ty> for $name<$lanes>
         where
-            BitMask<$lanes>: LanesAtMost64,
+            $bits_ty: LanesAtMost64,
         {
             fn from(value: $inner_ty) -> Self {
                 Self(value)
@@ -70,50 +78,72 @@ macro_rules! define_opaque_mask {
 
         impl<const $lanes: usize> From<$name<$lanes>> for $inner_ty
         where
-            BitMask<$lanes>: LanesAtMost64,
+            $bits_ty: LanesAtMost64,
         {
             fn from(value: $name<$lanes>) -> Self {
                 value.0
             }
         }
 
-        impl<const $lanes: usize> Copy for $name<$lanes> where BitMask<$lanes>: LanesAtMost64 {}
+        impl<const $lanes: usize> Copy for $name<$lanes>
+        where
+            $inner_ty: Copy,
+            $bits_ty: LanesAtMost64,
+        {}
 
-        impl<const $lanes: usize> Clone for $name<$lanes> where BitMask<$lanes>: LanesAtMost64 {
+        impl<const $lanes: usize> Clone for $name<$lanes>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn clone(&self) -> Self {
                 *self
             }
         }
 
-        impl<const $lanes: usize> Default for $name<$lanes> where BitMask<$lanes>: LanesAtMost64 {
+        impl<const $lanes: usize> Default for $name<$lanes>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn default() -> Self {
                 Self::splat(false)
             }
         }
 
-        impl<const $lanes: usize> PartialEq for $name<$lanes> where BitMask<$lanes>: LanesAtMost64 {
+        impl<const $lanes: usize> PartialEq for $name<$lanes>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
                 self.0 == other.0
             }
         }
 
-        impl<const $lanes: usize> PartialOrd for $name<$lanes> where BitMask<$lanes>: LanesAtMost64 {
+        impl<const $lanes: usize> PartialOrd for $name<$lanes>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
                 self.0.partial_cmp(&other.0)
             }
         }
 
-        impl<const $lanes: usize> core::fmt::Debug for $name<$lanes> where BitMask<$lanes>: LanesAtMost64 {
+        impl<const $lanes: usize> core::fmt::Debug for $name<$lanes>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 core::fmt::Debug::fmt(&self.0, f)
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAnd for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitAnd for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitand(self, rhs: Self) -> Self {
@@ -121,7 +151,10 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAnd<bool> for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitAnd<bool> for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitand(self, rhs: bool) -> Self {
@@ -129,7 +162,10 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAnd<$name<LANES>> for bool where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitAnd<$name<LANES>> for bool
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = $name<LANES>;
             #[inline]
             fn bitand(self, rhs: $name<LANES>) -> $name<LANES> {
@@ -137,7 +173,10 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOr for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitOr for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitor(self, rhs: Self) -> Self {
@@ -145,7 +184,10 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOr<bool> for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitOr<bool> for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitor(self, rhs: bool) -> Self {
@@ -153,7 +195,10 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOr<$name<LANES>> for bool where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitOr<$name<LANES>> for bool
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = $name<LANES>;
             #[inline]
             fn bitor(self, rhs: $name<LANES>) -> $name<LANES> {
@@ -161,7 +206,10 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXor for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitXor for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitxor(self, rhs: Self) -> Self::Output {
@@ -169,7 +217,10 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXor<bool> for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitXor<bool> for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = Self;
             #[inline]
             fn bitxor(self, rhs: bool) -> Self::Output {
@@ -177,7 +228,10 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXor<$name<LANES>> for bool where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitXor<$name<LANES>> for bool
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = $name<LANES>;
             #[inline]
             fn bitxor(self, rhs: $name<LANES>) -> Self::Output {
@@ -185,7 +239,10 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::Not for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::Not for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             type Output = $name<LANES>;
             #[inline]
             fn not(self) -> Self::Output {
@@ -193,42 +250,60 @@ macro_rules! define_opaque_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAndAssign for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitAndAssign for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn bitand_assign(&mut self, rhs: Self) {
                 self.0 &= rhs.0;
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAndAssign<bool> for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitAndAssign<bool> for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn bitand_assign(&mut self, rhs: bool) {
                 *self &= Self::splat(rhs);
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOrAssign for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitOrAssign for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn bitor_assign(&mut self, rhs: Self) {
                 self.0 |= rhs.0;
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOrAssign<bool> for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitOrAssign<bool> for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn bitor_assign(&mut self, rhs: bool) {
                 *self |= Self::splat(rhs);
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXorAssign for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitXorAssign for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn bitxor_assign(&mut self, rhs: Self) {
                 self.0 ^= rhs.0;
             }
         }
 
-        impl<const LANES: usize> core::ops::BitXorAssign<bool> for $name<LANES> where BitMask<LANES>: LanesAtMost64 {
+        impl<const LANES: usize> core::ops::BitXorAssign<bool> for $name<LANES>
+        where
+            $bits_ty: LanesAtMost64,
+        {
             #[inline]
             fn bitxor_assign(&mut self, rhs: bool) {
                 *self ^= Self::splat(rhs);
@@ -242,6 +317,7 @@ define_opaque_mask! {
     ///
     /// The layout of this type is unspecified.
     struct Mask8<const LANES: usize>(SimdMask8<LANES>);
+    @bits crate::SimdI8<LANES>
 }
 
 define_opaque_mask! {
@@ -249,6 +325,7 @@ define_opaque_mask! {
     ///
     /// The layout of this type is unspecified.
     struct Mask16<const LANES: usize>(SimdMask16<LANES>);
+    @bits crate::SimdI16<LANES>
 }
 
 define_opaque_mask! {
@@ -256,6 +333,7 @@ define_opaque_mask! {
     ///
     /// The layout of this type is unspecified.
     struct Mask32<const LANES: usize>(SimdMask32<LANES>);
+    @bits crate::SimdI32<LANES>
 }
 
 define_opaque_mask! {
@@ -263,6 +341,7 @@ define_opaque_mask! {
     ///
     /// The layout of this type is unspecified.
     struct Mask64<const LANES: usize>(SimdMask64<LANES>);
+    @bits crate::SimdI64<LANES>
 }
 
 define_opaque_mask! {
@@ -270,6 +349,7 @@ define_opaque_mask! {
     ///
     /// The layout of this type is unspecified.
     struct Mask128<const LANES: usize>(SimdMask128<LANES>);
+    @bits crate::SimdI128<LANES>
 }
 
 define_opaque_mask! {
@@ -277,12 +357,17 @@ define_opaque_mask! {
     ///
     /// The layout of this type is unspecified.
     struct MaskSize<const LANES: usize>(SimdMaskSize<LANES>);
+    @bits crate::SimdIsize<LANES>
 }
 
 macro_rules! implement_mask_ops {
-    { $($vector:ident => $mask:ident,)* } => {
+    { $($vector:ident => $mask:ident ($inner_ty:ident),)* } => {
         $(
-            impl<const LANES: usize> crate::$vector<LANES> where BitMask<LANES>: LanesAtMost64 {
+            impl<const LANES: usize> crate::$vector<LANES>
+            where
+                crate::$vector<LANES>: LanesAtMost64,
+                crate::$inner_ty<LANES>: LanesAtMost64,
+            {
                 /// Test if each lane is equal to the corresponding lane in `other`.
                 #[inline]
                 pub fn lanes_eq(&self, other: &Self) -> $mask<LANES> {
@@ -324,22 +409,22 @@ macro_rules! implement_mask_ops {
 }
 
 implement_mask_ops! {
-    SimdI8 => Mask8,
-    SimdI16 => Mask16,
-    SimdI32 => Mask32,
-    SimdI64 => Mask64,
-    SimdI128 => Mask128,
-    SimdIsize => MaskSize,
+    SimdI8 => Mask8 (SimdI8),
+    SimdI16 => Mask16 (SimdI16),
+    SimdI32 => Mask32 (SimdI32),
+    SimdI64 => Mask64 (SimdI64),
+    SimdI128 => Mask128 (SimdI128),
+    SimdIsize => MaskSize (SimdIsize),
 
-    SimdU8 => Mask8,
-    SimdU16 => Mask16,
-    SimdU32 => Mask32,
-    SimdU64 => Mask64,
-    SimdU128 => Mask128,
-    SimdUsize => MaskSize,
+    SimdU8 => Mask8 (SimdI8),
+    SimdU16 => Mask16 (SimdI16),
+    SimdU32 => Mask32 (SimdI32),
+    SimdU64 => Mask64 (SimdI64),
+    SimdU128 => Mask128 (SimdI128),
+    SimdUsize => MaskSize (SimdIsize),
 
-    SimdF32 => Mask32,
-    SimdF64 => Mask64,
+    SimdF32 => Mask32 (SimdI32),
+    SimdF64 => Mask64 (SimdI64),
 }
 
 /// Vector of eight 8-bit masks

--- a/crates/core_simd/src/round.rs
+++ b/crates/core_simd/src/round.rs
@@ -2,7 +2,10 @@ macro_rules! implement {
     {
         $type:ident, $int_type:ident
     } => {
-        impl<const LANES: usize> crate::$type<LANES> {
+        impl<const LANES: usize> crate::$type<LANES>
+        where
+            Self: crate::LanesAtMost64,
+        {
             /// Returns the largest integer less than or equal to each lane.
             #[must_use = "method returns a new vector and does not mutate the original value"]
             #[inline]
@@ -16,7 +19,13 @@ macro_rules! implement {
             pub fn ceil(self) -> Self {
                 unsafe { crate::intrinsics::simd_ceil(self) }
             }
+        }
 
+        impl<const LANES: usize> crate::$type<LANES>
+        where
+            Self: crate::LanesAtMost64,
+            crate::$int_type<LANES>: crate::LanesAtMost64,
+        {
             /// Rounds toward zero and converts to the same-width integer type, assuming that
             /// the value is finite and fits in that type.
             ///

--- a/crates/core_simd/src/vectors_f32.rs
+++ b/crates/core_simd/src/vectors_f32.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `f32` values.
 #[repr(simd)]
-pub struct SimdF32<const LANES: usize>([f32; LANES]);
+pub struct SimdF32<const LANES: usize>([f32; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_float_vector! { SimdF32, f32, SimdU32 }
 

--- a/crates/core_simd/src/vectors_f64.rs
+++ b/crates/core_simd/src/vectors_f64.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `f64` values.
 #[repr(simd)]
-pub struct SimdF64<const LANES: usize>([f64; LANES]);
+pub struct SimdF64<const LANES: usize>([f64; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_float_vector! { SimdF64, f64, SimdU64 }
 

--- a/crates/core_simd/src/vectors_i128.rs
+++ b/crates/core_simd/src/vectors_i128.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `i128` values.
 #[repr(simd)]
-pub struct SimdI128<const LANES: usize>([i128; LANES]);
+pub struct SimdI128<const LANES: usize>([i128; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdI128, i128 }
 

--- a/crates/core_simd/src/vectors_i16.rs
+++ b/crates/core_simd/src/vectors_i16.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `i16` values.
 #[repr(simd)]
-pub struct SimdI16<const LANES: usize>([i16; LANES]);
+pub struct SimdI16<const LANES: usize>([i16; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdI16, i16 }
 

--- a/crates/core_simd/src/vectors_i32.rs
+++ b/crates/core_simd/src/vectors_i32.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `i32` values.
 #[repr(simd)]
-pub struct SimdI32<const LANES: usize>([i32; LANES]);
+pub struct SimdI32<const LANES: usize>([i32; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdI32, i32 }
 

--- a/crates/core_simd/src/vectors_i64.rs
+++ b/crates/core_simd/src/vectors_i64.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `i64` values.
 #[repr(simd)]
-pub struct SimdI64<const LANES: usize>([i64; LANES]);
+pub struct SimdI64<const LANES: usize>([i64; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdI64, i64 }
 

--- a/crates/core_simd/src/vectors_i8.rs
+++ b/crates/core_simd/src/vectors_i8.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `i8` values.
 #[repr(simd)]
-pub struct SimdI8<const LANES: usize>([i8; LANES]);
+pub struct SimdI8<const LANES: usize>([i8; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdI8, i8 }
 

--- a/crates/core_simd/src/vectors_isize.rs
+++ b/crates/core_simd/src/vectors_isize.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `isize` values.
 #[repr(simd)]
-pub struct SimdIsize<const LANES: usize>([isize; LANES]);
+pub struct SimdIsize<const LANES: usize>([isize; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdIsize, isize }
 

--- a/crates/core_simd/src/vectors_u128.rs
+++ b/crates/core_simd/src/vectors_u128.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `u128` values.
 #[repr(simd)]
-pub struct SimdU128<const LANES: usize>([u128; LANES]);
+pub struct SimdU128<const LANES: usize>([u128; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdU128, u128 }
 

--- a/crates/core_simd/src/vectors_u16.rs
+++ b/crates/core_simd/src/vectors_u16.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `u16` values.
 #[repr(simd)]
-pub struct SimdU16<const LANES: usize>([u16; LANES]);
+pub struct SimdU16<const LANES: usize>([u16; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdU16, u16 }
 

--- a/crates/core_simd/src/vectors_u32.rs
+++ b/crates/core_simd/src/vectors_u32.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `u32` values.
 #[repr(simd)]
-pub struct SimdU32<const LANES: usize>([u32; LANES]);
+pub struct SimdU32<const LANES: usize>([u32; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdU32, u32 }
 

--- a/crates/core_simd/src/vectors_u64.rs
+++ b/crates/core_simd/src/vectors_u64.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `u64` values.
 #[repr(simd)]
-pub struct SimdU64<const LANES: usize>([u64; LANES]);
+pub struct SimdU64<const LANES: usize>([u64; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdU64, u64 }
 

--- a/crates/core_simd/src/vectors_u8.rs
+++ b/crates/core_simd/src/vectors_u8.rs
@@ -2,7 +2,7 @@
 
 /// A SIMD vector of containing `LANES` `u8` values.
 #[repr(simd)]
-pub struct SimdU8<const LANES: usize>([u8; LANES]);
+pub struct SimdU8<const LANES: usize>([u8; LANES]) where Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdU8, u8 }
 

--- a/crates/core_simd/src/vectors_usize.rs
+++ b/crates/core_simd/src/vectors_usize.rs
@@ -2,7 +2,9 @@
 
 /// A SIMD vector of containing `LANES` `usize` values.
 #[repr(simd)]
-pub struct SimdUsize<const LANES: usize>([usize; LANES]);
+pub struct SimdUsize<const LANES: usize>([usize; LANES])
+where
+    Self: crate::LanesAtMost64;
 
 impl_integer_vector! { SimdUsize, usize }
 


### PR DESCRIPTION
In https://github.com/rust-lang/rust/issues/27731, @oli-obk indicated some concern over allowing monomorphization errors (which are definitely not user-friendly).

This PR extends the `LanesAtMost64` trait to be implemented over _all_ vector types.  This adds a bit of complexity to the implementation.

This solution seems pretty good, but before going with it I want to be sure the following are true:
* Vectors will be useful after stabilization even if the `LanesAtMost64` trait never gets stabilized (much like the now-removed `std::array::LengthAtMost32`).  Considering I didn't need to update the tests, I think this is true.
* We can remove all traces of this trait without breaking the API
* We can change the bound in the future to add more support (such as wider vectors, or non-powers-of-two #63)