### PR TITLE
Add to glossary: vectorize, scalar, vector register

### DIFF
--- a/beginners-guide.md
+++ b/beginners-guide.md
@@ -19,9 +19,17 @@ SIMD has a few special vocabulary terms you should know:
 
 * **Vector:** A SIMD value is called a vector. This shouldn't be confused with the `Vec<T>` type. A SIMD vector has a fixed size, known at compile time. All of the elements within the vector are of the same type. This makes vectors *similar to* arrays. One difference is that a vector is generally aligned to its *entire* size (eg: 16 bytes, 32 bytes, etc), not just the size of an individual element. Sometimes vector data is called "packed" data.
 
+* **Vectorize**: An operation that uses SIMD instructions to operate over a vector is often referred to as "vectorized".
+
+* **Autovectorization**: Also known as _implicit vectorization_. This is when a compiler can automatically recognize a situation where scalar instructions may be replaced with SIMD instructions, and use those instead.
+
+* **Scalar:** "Scalar" in mathematical contexts refers to values that can be represented as a single element, mostly numbers like 6, 3.14, or -2. It can also be used to describe "scalar operations" that use strictly scalar values, like addition. This term is mostly used to differentiate between vectorized operations that use SIMD instructions and scalar operations that don't.
+
 * **Lane:** A single element position within a vector is called a lane. If you have `N` lanes available then they're numbered from `0` to `N-1` when referring to them, again like an array. The biggest difference between an array element and a vector lane is that in general is *relatively costly* to access an individual lane value. On most architectures, the vector has to be pushed out of the SIMD register onto the stack, then an individual lane is accessed while it's on the stack (and possibly the stack value is read back into a register). For this reason, when working with SIMD you should avoid reading or writing the value of an individual lane during hot loops.
 
 * **Bit Widths:** When talking about SIMD, the bit widths used are the bit size of the vectors involved, *not* the individual elements. So "128-bit SIMD" has 128-bit vectors, and that might be `f32x4`, `i32x4`, `i16x8`, or other variations. While 128-bit SIMD is the most common, there's also 64-bit, 256-bit, and even 512-bit on the newest CPUs.
+
+* **Vector Register:** The extra-wide registers that are used for SIMD operations are commonly called vector registers, though you may also see "SIMD registers", vendor names for specific features, or even "floating-point register" as it is common for the same registers to be used with both scalar and vectorized floating-point operations.
 
 * **Vertical:** When an operation is "vertical", each lane processes individually without regard to the other lanes in the same vector. For example, a "vertical add" between two vectors would add lane 0 in `a` with lane 0 in `b`, with the total in lane 0 of `out`, and then the same thing for lanes 1, 2, etc. Most SIMD operations are vertical operations, so if your problem is a vertical problem then you can probably solve it with SIMD.
 

--- a/crates/core_simd/tests/helpers/lanewise.rs
+++ b/crates/core_simd/tests/helpers/lanewise.rs
@@ -1,3 +1,10 @@
+//! These helpers provide a way to easily emulate a vectorized SIMD op on two SIMD vectors,
+//! except using scalar ops that iterate through each lane, one at a time, so as to remove
+//! the vagaries of compilation.
+//!
+//! Do note, however, that when testing that vectorized operations #[should_panic], these
+//! "scalarized SIMD ops" will trigger scalar code paths that may also normally panic.
+
 pub fn apply_unary_lanewise<T1: Copy, T2: Copy, V1: AsRef<[T1]>, V2: AsMut<[T2]> + Default>(
     x: V1,
     f: impl Fn(T1) -> T2,


### PR DESCRIPTION
This primarily adds to the documentation a handful of terms that were unclear to @miguelraz when he was trying to make a contribution, inching the guide towards greater usefulness to the next comer. It also directly explains the purpose of some helper functions for our tests since they might have confusing names for someone who isn't used to SIMD.