### PR TITLE
Remove From<Scalar> for SimdTy impl

### DIFF
--- a/crates/core_simd/src/macros.rs
+++ b/crates/core_simd/src/macros.rs
@@ -147,14 +147,6 @@ macro_rules! impl_vector {
             }
         }
 
-        // splat
-        impl<const LANES: usize> From<$type> for $name<LANES> where Self: crate::LanesAtMost64 {
-            #[inline]
-            fn from(value: $type) -> Self {
-                Self::splat(value)
-            }
-        }
-
         impl_shuffle_2pow_lanes!{ $name }
     }
 }


### PR DESCRIPTION
0. It was not being tested.
1. The possible conversions are ambiguous between splatting
   and setting a single value but zero-initializing the rest.
2. Splat works fine.

This closes #69.