### PR TITLE
Use fabs intrinsic

### DIFF
--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -51,6 +51,9 @@ extern "platform-intrinsic" {
     #[cfg(feature = "std")]
     pub(crate) fn simd_ceil<T>(x: T) -> T;
 
+    /// fabs
+    pub(crate) fn simd_fabs<T>(x: T) -> T;
+
     pub(crate) fn simd_eq<T, U>(x: T, y: T) -> U;
     pub(crate) fn simd_ne<T, U>(x: T, y: T) -> U;
     pub(crate) fn simd_lt<T, U>(x: T, y: T) -> U;

--- a/crates/core_simd/src/vector/float.rs
+++ b/crates/core_simd/src/vector/float.rs
@@ -32,8 +32,7 @@ macro_rules! impl_float_vector {
             /// equivalently-indexed lane in `self`.
             #[inline]
             pub fn abs(self) -> Self {
-                let no_sign = crate::$bits_ty::splat(!0 >> 1);
-                Self::from_bits(self.to_bits() & no_sign)
+                unsafe { crate::intrinsics::simd_fabs(self) }
             }
         }
 


### PR DESCRIPTION
I noticed there's a `simd_fabs` even though there is no `simd_abs`.
Same story as #89.