### PR TITLE
Reduce wasm test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,29 +42,28 @@ matrix:
       env: RUSTFLAGS=-Ctarget-feature=+avx512vl
 
     # WebAssembly (wasm-bindgen)
-    - name: "wasm32-unknown-unknown (node, firefox, chrome)"
+    - name: "wasm32-unknown-unknown (firefox)"
       os: linux
       arch: amd64
       addons:
-        firefox: latest
-        chrome: stable
+        firefox: latest-nightly
       install:
         - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       script:
-        - wasm-pack test --node --firefox --chrome --headless crates/core_simd
-        - wasm-pack test --node --firefox --chrome --headless crates/core_simd --release
+        - wasm-pack test --firefox --headless crates/core_simd
+        - wasm-pack test --firefox --headless crates/core_simd --release
 
-    - name: "wasm32-unknown-unknown+simd128 (chrome)"
+    - name: "wasm32-unknown-unknown+simd128 (firefox)"
       os: linux
       arch: amd64
       addons:
-        chrome: stable
+        firefox: latest-nightly
       install:
         - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       script:
         - export RUSTFLAGS="-C target-feature=+simd128"
-        - wasm-pack test --chrome --headless crates/core_simd
-        - wasm-pack test --chrome --headless crates/core_simd --release
+        - wasm-pack test --firefox --headless crates/core_simd
+        - wasm-pack test --firefox --headless crates/core_simd --release
 
 script:
   - echo "## Requested target configuration (RUSTFLAGS=$RUSTFLAGS)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,17 +53,18 @@ matrix:
         - wasm-pack test --firefox --headless crates/core_simd
         - wasm-pack test --firefox --headless crates/core_simd --release
 
-    - name: "wasm32-unknown-unknown+simd128 (firefox)"
-      os: linux
-      arch: amd64
-      addons:
-        firefox: latest-nightly
-      install:
-        - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      script:
-        - export RUSTFLAGS="-C target-feature=+simd128"
-        - wasm-pack test --firefox --headless crates/core_simd
-        - wasm-pack test --firefox --headless crates/core_simd --release
+    # FIXME: See https://github.com/rust-lang/stdsimd/issues/92
+    # - name: "wasm32-unknown-unknown+simd128 (firefox)"
+    #   os: linux
+    #   arch: amd64
+    #   addons:
+    #     firefox: latest-nightly
+    #   install:
+    #     - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+    #   script:
+    #     - export RUSTFLAGS="-C target-feature=+simd128"
+    #     - wasm-pack test --firefox --headless crates/core_simd
+    #     - wasm-pack test --firefox --headless crates/core_simd --release
 
 script:
   - echo "## Requested target configuration (RUSTFLAGS=$RUSTFLAGS)"

--- a/crates/core_simd/src/transmute.rs
+++ b/crates/core_simd/src/transmute.rs
@@ -1,4 +1,5 @@
 /// Provides implementations of `From<$a> for $b` and `From<$b> for $a` that transmutes the value.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! from_transmute {
     { unsafe $a:ty => $b:ty } => {
         from_transmute!{ @impl $a => $b }

--- a/crates/core_simd/tests/f32_ops.rs
+++ b/crates/core_simd/tests/f32_ops.rs
@@ -1,5 +1,3 @@
-#![feature(is_subnormal)]
-
 #[macro_use]
 mod ops_macros;
 impl_float_tests! { SimdF32, f32, i32 }

--- a/crates/core_simd/tests/f64_ops.rs
+++ b/crates/core_simd/tests/f64_ops.rs
@@ -1,5 +1,3 @@
-#![feature(is_subnormal)]
-
 #[macro_use]
 mod ops_macros;
 impl_float_tests! { SimdF64, f64, i64 }


### PR DESCRIPTION
Fighting CI over #92.

Node is removed from CI because it was apparently never actually being tested: when I ran the test suite locally, it appeared to skip all the tests. Chrome is removed from CI because Chrome Beta drops connections more often and Firefox Nightly allows us to test on the latest Firefox.

Something still fails inside wasm-bindgen, so I omitted the relevant tests.