### PR TITLE
Feature/simplify masks

### DIFF
--- a/crates/core_simd/src/comparisons.rs
+++ b/crates/core_simd/src/comparisons.rs
@@ -1,7 +1,7 @@
 use crate::LanesAtMost32;
 
 macro_rules! implement_mask_ops {
-    { $($vector:ident => $mask:ident ($inner_mask_ty:ident, $inner_ty:ident),)* } => {
+    { $($vector:ident => $mask:ident ($inner_ty:ident),)* } => {
         $(
             impl<const LANES: usize> crate::$vector<LANES>
             where
@@ -12,8 +12,7 @@ macro_rules! implement_mask_ops {
                 #[inline]
                 pub fn lanes_eq(self, other: Self) -> crate::$mask<LANES> {
                     unsafe {
-                        crate::$inner_mask_ty::from_int_unchecked(crate::intrinsics::simd_eq(self, other))
-                            .into()
+                        crate::$mask::from_int_unchecked(crate::intrinsics::simd_eq(self, other))
                     }
                 }
 
@@ -21,8 +20,7 @@ macro_rules! implement_mask_ops {
                 #[inline]
                 pub fn lanes_ne(self, other: Self) -> crate::$mask<LANES> {
                     unsafe {
-                        crate::$inner_mask_ty::from_int_unchecked(crate::intrinsics::simd_ne(self, other))
-                            .into()
+                        crate::$mask::from_int_unchecked(crate::intrinsics::simd_ne(self, other))
                     }
                 }
 
@@ -30,8 +28,7 @@ macro_rules! implement_mask_ops {
                 #[inline]
                 pub fn lanes_lt(self, other: Self) -> crate::$mask<LANES> {
                     unsafe {
-                        crate::$inner_mask_ty::from_int_unchecked(crate::intrinsics::simd_lt(self, other))
-                            .into()
+                        crate::$mask::from_int_unchecked(crate::intrinsics::simd_lt(self, other))
                     }
                 }
 
@@ -39,8 +36,7 @@ macro_rules! implement_mask_ops {
                 #[inline]
                 pub fn lanes_gt(self, other: Self) -> crate::$mask<LANES> {
                     unsafe {
-                        crate::$inner_mask_ty::from_int_unchecked(crate::intrinsics::simd_gt(self, other))
-                            .into()
+                        crate::$mask::from_int_unchecked(crate::intrinsics::simd_gt(self, other))
                     }
                 }
 
@@ -48,8 +44,7 @@ macro_rules! implement_mask_ops {
                 #[inline]
                 pub fn lanes_le(self, other: Self) -> crate::$mask<LANES> {
                     unsafe {
-                        crate::$inner_mask_ty::from_int_unchecked(crate::intrinsics::simd_le(self, other))
-                            .into()
+                        crate::$mask::from_int_unchecked(crate::intrinsics::simd_le(self, other))
                     }
                 }
 
@@ -57,8 +52,7 @@ macro_rules! implement_mask_ops {
                 #[inline]
                 pub fn lanes_ge(self, other: Self) -> crate::$mask<LANES> {
                     unsafe {
-                        crate::$inner_mask_ty::from_int_unchecked(crate::intrinsics::simd_ge(self, other))
-                            .into()
+                        crate::$mask::from_int_unchecked(crate::intrinsics::simd_ge(self, other))
                     }
                 }
             }
@@ -67,18 +61,18 @@ macro_rules! implement_mask_ops {
 }
 
 implement_mask_ops! {
-    SimdI8 => Mask8 (SimdMask8, SimdI8),
-    SimdI16 => Mask16 (SimdMask16, SimdI16),
-    SimdI32 => Mask32 (SimdMask32, SimdI32),
-    SimdI64 => Mask64 (SimdMask64, SimdI64),
-    SimdIsize => MaskSize (SimdMaskSize, SimdIsize),
+    SimdI8 => Mask8 (SimdI8),
+    SimdI16 => Mask16 (SimdI16),
+    SimdI32 => Mask32 (SimdI32),
+    SimdI64 => Mask64 (SimdI64),
+    SimdIsize => MaskSize (SimdIsize),
 
-    SimdU8 => Mask8 (SimdMask8, SimdI8),
-    SimdU16 => Mask16 (SimdMask16, SimdI16),
-    SimdU32 => Mask32 (SimdMask32, SimdI32),
-    SimdU64 => Mask64 (SimdMask64, SimdI64),
-    SimdUsize => MaskSize (SimdMaskSize, SimdIsize),
+    SimdU8 => Mask8 (SimdI8),
+    SimdU16 => Mask16 (SimdI16),
+    SimdU32 => Mask32 (SimdI32),
+    SimdU64 => Mask64 (SimdI64),
+    SimdUsize => MaskSize (SimdIsize),
 
-    SimdF32 => Mask32 (SimdMask32, SimdI32),
-    SimdF64 => Mask64 (SimdMask64, SimdI64),
+    SimdF32 => Mask32 (SimdI32),
+    SimdF64 => Mask64 (SimdI64),
 }

--- a/crates/core_simd/src/comparisons.rs
+++ b/crates/core_simd/src/comparisons.rs
@@ -7,6 +7,7 @@ macro_rules! implement_mask_ops {
             where
                 crate::$vector<LANES>: LanesAtMost32,
                 crate::$inner_ty<LANES>: LanesAtMost32,
+                crate::$mask<LANES>: crate::Mask,
             {
                 /// Test if each lane is equal to the corresponding lane in `other`.
                 #[inline]

--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -79,6 +79,9 @@ extern "platform-intrinsic" {
 
     // truncate integer vector to bitmask
     pub(crate) fn simd_bitmask<T, U>(x: T) -> U;
+
+    // select
+    pub(crate) fn simd_select_bitmask<T, U>(m: T, a: U, b: U) -> U;
 }
 
 #[cfg(feature = "std")]

--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -76,6 +76,9 @@ extern "platform-intrinsic" {
     pub(crate) fn simd_reduce_and<T, U>(x: T) -> U;
     pub(crate) fn simd_reduce_or<T, U>(x: T) -> U;
     pub(crate) fn simd_reduce_xor<T, U>(x: T) -> U;
+
+    // truncate integer vector to bitmask
+    pub(crate) fn simd_bitmask<T, U>(x: T) -> U;
 }
 
 #[cfg(feature = "std")]

--- a/crates/core_simd/src/lanes_at_most_32.rs
+++ b/crates/core_simd/src/lanes_at_most_32.rs
@@ -1,14 +1,38 @@
 /// Implemented for vectors that are supported by the implementation.
-pub trait LanesAtMost32 {}
+pub trait LanesAtMost32: sealed::Sealed {
+    #[doc(hidden)]
+    type BitMask: Into<u64>;
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
 
 macro_rules! impl_for {
     { $name:ident } => {
-        impl LanesAtMost32 for $name<1> {}
-        impl LanesAtMost32 for $name<2> {}
-        impl LanesAtMost32 for $name<4> {}
-        impl LanesAtMost32 for $name<8> {}
-        impl LanesAtMost32 for $name<16> {}
-        impl LanesAtMost32 for $name<32> {}
+        impl<const LANES: usize> sealed::Sealed for $name<LANES>
+        where
+            $name<LANES>: LanesAtMost32,
+        {}
+
+        impl LanesAtMost32 for $name<1> {
+            type BitMask = u8;
+        }
+        impl LanesAtMost32 for $name<2> {
+            type BitMask = u8;
+        }
+        impl LanesAtMost32 for $name<4> {
+            type BitMask = u8;
+        }
+        impl LanesAtMost32 for $name<8> {
+            type BitMask = u8;
+        }
+        impl LanesAtMost32 for $name<16> {
+            type BitMask = u16;
+        }
+        impl LanesAtMost32 for $name<32> {
+            type BitMask = u32;
+        }
     }
 }
 

--- a/crates/core_simd/src/lanes_at_most_32.rs
+++ b/crates/core_simd/src/lanes_at_most_32.rs
@@ -1,4 +1,4 @@
-/// Implemented for bitmask sizes that are supported by the implementation.
+/// Implemented for vectors that are supported by the implementation.
 pub trait LanesAtMost32 {}
 
 macro_rules! impl_for {
@@ -28,5 +28,3 @@ impl_for! { SimdIsize }
 
 impl_for! { SimdF32 }
 impl_for! { SimdF64 }
-
-impl_for! { BitMask }

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -4,14 +4,12 @@ use crate::LanesAtMost32;
 #[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Ord, Eq, Hash)]
 #[repr(transparent)]
 pub struct BitMask<const LANES: usize>(u64)
-where
-    BitMask<LANES>: LanesAtMost32;
 
 impl<const LANES: usize> BitMask<LANES>
 where
     Self: LanesAtMost32,
 {
-    /// Construct a mask by setting all lanes to the given value.
+    #[inline]
     pub fn splat(value: bool) -> Self {
         if value {
             Self(u64::MAX >> (64 - LANES))
@@ -20,23 +18,13 @@ where
         }
     }
 
-    /// Tests the value of the specified lane.
-    ///
-    /// # Panics
-    /// Panics if `lane` is greater than or equal to the number of lanes in the vector.
     #[inline]
-    pub fn test(&self, lane: usize) -> bool {
-        assert!(lane < LANES, "lane index out of range");
+    pub unsafe fn test_unchecked(&self, lane: usize) -> bool {
         (self.0 >> lane) & 0x1 > 0
     }
 
-    /// Sets the value of the specified lane.
-    ///
-    /// # Panics
-    /// Panics if `lane` is greater than or equal to the number of lanes in the vector.
     #[inline]
-    pub fn set(&mut self, lane: usize, value: bool) {
-        assert!(lane < LANES, "lane index out of range");
+    pub unsafe fn set_unchecked(&mut self, lane: usize, value: bool) {
         self.0 ^= ((value ^ self.test(lane)) as u64) << lane
     }
 }

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -1,42 +1,80 @@
-/// A mask where each lane is represented by a single bit.
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Ord, Eq, Hash)]
-#[repr(transparent)]
-pub struct BitMask<const LANES: usize>(u64);
+use crate::Mask;
+use core::marker::PhantomData;
 
-impl<const LANES: usize> BitMask<LANES>
-{
+/// Helper trait for limiting int conversion types
+pub trait ConvertToInt {}
+impl<const LANES: usize> ConvertToInt for crate::SimdI8<LANES> where Self: crate::LanesAtMost32 {}
+impl<const LANES: usize> ConvertToInt for crate::SimdI16<LANES> where Self: crate::LanesAtMost32 {}
+impl<const LANES: usize> ConvertToInt for crate::SimdI32<LANES> where Self: crate::LanesAtMost32 {}
+impl<const LANES: usize> ConvertToInt for crate::SimdI64<LANES> where Self: crate::LanesAtMost32 {}
+impl<const LANES: usize> ConvertToInt for crate::SimdIsize<LANES> where Self: crate::LanesAtMost32 {}
+
+/// A mask where each lane is represented by a single bit.
+#[repr(transparent)]
+pub struct BitMask<T: Mask, const LANES: usize>(T::BitMask, PhantomData<[(); LANES]>);
+
+impl<T: Mask, const LANES: usize> Copy for BitMask<T, LANES> {}
+
+impl<T: Mask, const LANES: usize> Clone for BitMask<T, LANES> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Mask, const LANES: usize> PartialEq for BitMask<T, LANES> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_ref() == other.0.as_ref()
+    }
+}
+
+impl<T: Mask, const LANES: usize> PartialOrd for BitMask<T, LANES> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        self.0.as_ref().partial_cmp(other.0.as_ref())
+    }
+}
+
+impl<T: Mask, const LANES: usize> Eq for BitMask<T, LANES> {}
+
+impl<T: Mask, const LANES: usize> Ord for BitMask<T, LANES> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.as_ref().cmp(other.0.as_ref())
+    }
+}
+
+impl<T: Mask, const LANES: usize> BitMask<T, LANES> {
     #[inline]
     pub fn splat(value: bool) -> Self {
+        let mut mask = T::BitMask::default();
         if value {
-            Self(u64::MAX >> (64 - LANES))
+            mask.as_mut().fill(u8::MAX)
         } else {
-            Self(u64::MIN)
+            mask.as_mut().fill(u8::MIN)
         }
+        if LANES % 8 > 0 {
+            *mask.as_mut().last_mut().unwrap() &= u8::MAX >> (8 - LANES % 8);
+        }
+        Self(mask, PhantomData)
     }
 
     #[inline]
     pub unsafe fn test_unchecked(&self, lane: usize) -> bool {
-        (self.0 >> lane) & 0x1 > 0
+        (self.0.as_ref()[lane / 8] >> lane % 8) & 0x1 > 0
     }
 
     #[inline]
     pub unsafe fn set_unchecked(&mut self, lane: usize, value: bool) {
-        self.0 ^= ((value ^ self.test_unchecked(lane)) as u64) << lane
+        self.0.as_mut()[lane / 8] ^= ((value ^ self.test_unchecked(lane)) as u8) << (lane % 8)
     }
 
     #[inline]
-    pub fn to_int<V, T>(self) -> V
+    pub fn to_int<V>(self) -> V
     where
-        V: Default + AsMut<[T; LANES]>,
-        T: From<i8>,
+        V: ConvertToInt + Default + core::ops::Not<Output = V>,
     {
-        // TODO this should be an intrinsic sign-extension
-        let mut v = V::default();
-        for i in 0..LANES {
-            let lane = unsafe { self.test_unchecked(i) };
-            v.as_mut()[i] = (-(lane as i8)).into();
+        unsafe {
+            let mask: T::IntBitMask = core::mem::transmute_copy(&self);
+            crate::intrinsics::simd_select_bitmask(mask, !V::default(), V::default())
         }
-        v
     }
 
     #[inline]
@@ -44,13 +82,22 @@ impl<const LANES: usize> BitMask<LANES>
     where
         V: crate::LanesAtMost32,
     {
-        let mask: V::BitMask = crate::intrinsics::simd_bitmask(value);
-        Self(mask.into())
+        // TODO remove the transmute when rustc is more flexible
+        assert_eq!(
+            core::mem::size_of::<T::IntBitMask>(),
+            core::mem::size_of::<T::BitMask>()
+        );
+        let mask: T::IntBitMask = crate::intrinsics::simd_bitmask(value);
+        Self(core::mem::transmute_copy(&mask), PhantomData)
     }
 
     #[inline]
-    pub fn to_bitmask(self) -> u64 {
-        self.0
+    pub fn to_bitmask<U: Mask>(self) -> U::BitMask {
+        assert_eq!(
+            core::mem::size_of::<T::BitMask>(),
+            core::mem::size_of::<U::BitMask>()
+        );
+        unsafe { core::mem::transmute_copy(&self.0) }
     }
 
     #[inline]
@@ -64,87 +111,61 @@ impl<const LANES: usize> BitMask<LANES>
     }
 }
 
-impl<const LANES: usize> core::ops::BitAnd for BitMask<LANES>
+impl<T: Mask, const LANES: usize> core::ops::BitAnd for BitMask<T, LANES>
+where
+    T::BitMask: Default + AsRef<[u8]> + AsMut<[u8]>,
 {
     type Output = Self;
     #[inline]
-    fn bitand(self, rhs: Self) -> Self {
-        Self(self.0 & rhs.0)
+    fn bitand(mut self, rhs: Self) -> Self {
+        for (l, r) in self.0.as_mut().iter_mut().zip(rhs.0.as_ref().iter()) {
+            *l &= r;
+        }
+        self
     }
 }
 
-impl<const LANES: usize> core::ops::BitAnd<bool> for BitMask<LANES>
+impl<T: Mask, const LANES: usize> core::ops::BitOr for BitMask<T, LANES>
+where
+    T::BitMask: Default + AsRef<[u8]> + AsMut<[u8]>,
 {
     type Output = Self;
     #[inline]
-    fn bitand(self, rhs: bool) -> Self {
-        self & Self::splat(rhs)
+    fn bitor(mut self, rhs: Self) -> Self {
+        for (l, r) in self.0.as_mut().iter_mut().zip(rhs.0.as_ref().iter()) {
+            *l |= r;
+        }
+        self
     }
 }
 
-impl<const LANES: usize> core::ops::BitAnd<BitMask<LANES>> for bool
-{
-    type Output = BitMask<LANES>;
-    #[inline]
-    fn bitand(self, rhs: BitMask<LANES>) -> BitMask<LANES> {
-        BitMask::<LANES>::splat(self) & rhs
-    }
-}
-
-impl<const LANES: usize> core::ops::BitOr for BitMask<LANES>
-{
+impl<T: Mask, const LANES: usize> core::ops::BitXor for BitMask<T, LANES> {
     type Output = Self;
     #[inline]
-    fn bitor(self, rhs: Self) -> Self {
-        Self(self.0 | rhs.0)
+    fn bitxor(mut self, rhs: Self) -> Self::Output {
+        for (l, r) in self.0.as_mut().iter_mut().zip(rhs.0.as_ref().iter()) {
+            *l ^= r;
+        }
+        self
     }
 }
 
-impl<const LANES: usize> core::ops::BitXor for BitMask<LANES>
-{
+impl<T: Mask, const LANES: usize> core::ops::Not for BitMask<T, LANES> {
     type Output = Self;
     #[inline]
-    fn bitxor(self, rhs: Self) -> Self::Output {
-        Self(self.0 ^ rhs.0)
+    fn not(mut self) -> Self::Output {
+        for x in self.0.as_mut() {
+            *x = !*x;
+        }
+        if LANES % 8 > 0 {
+            *self.0.as_mut().last_mut().unwrap() &= u8::MAX >> (8 - LANES % 8);
+        }
+        self
     }
 }
 
-impl<const LANES: usize> core::ops::Not for BitMask<LANES>
-{
-    type Output = BitMask<LANES>;
-    #[inline]
-    fn not(self) -> Self::Output {
-        Self(!self.0) & Self::splat(true)
-    }
-}
-
-impl<const LANES: usize> core::ops::BitAndAssign for BitMask<LANES>
-{
-    #[inline]
-    fn bitand_assign(&mut self, rhs: Self) {
-        self.0 &= rhs.0;
-    }
-}
-
-impl<const LANES: usize> core::ops::BitOrAssign for BitMask<LANES>
-{
-    #[inline]
-    fn bitor_assign(&mut self, rhs: Self) {
-        self.0 |= rhs.0;
-    }
-}
-
-impl<const LANES: usize> core::ops::BitXorAssign for BitMask<LANES>
-{
-    #[inline]
-    fn bitxor_assign(&mut self, rhs: Self) {
-        self.0 ^= rhs.0;
-    }
-}
-
-pub type Mask8<const LANES: usize> = BitMask<LANES>;
-pub type Mask16<const LANES: usize> = BitMask<LANES>;
-pub type Mask32<const LANES: usize> = BitMask<LANES>;
-pub type Mask64<const LANES: usize> = BitMask<LANES>;
-pub type Mask128<const LANES: usize> = BitMask<LANES>;
-pub type MaskSize<const LANES: usize> = BitMask<LANES>;
+pub type Mask8<T, const LANES: usize> = BitMask<T, LANES>;
+pub type Mask16<T, const LANES: usize> = BitMask<T, LANES>;
+pub type Mask32<T, const LANES: usize> = BitMask<T, LANES>;
+pub type Mask64<T, const LANES: usize> = BitMask<T, LANES>;
+pub type MaskSize<T, const LANES: usize> = BitMask<T, LANES>;

--- a/crates/core_simd/src/masks/full_masks.rs
+++ b/crates/core_simd/src/masks/full_masks.rs
@@ -1,18 +1,5 @@
 //! Masks that take up full SIMD vector registers.
 
-/// The error type returned when converting an integer to a mask fails.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct TryFromMaskError(());
-
-impl core::fmt::Display for TryFromMaskError {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(
-            f,
-            "mask vector must have all bits set or unset in each lane"
-        )
-    }
-}
-
 macro_rules! define_mask {
     {
         $(#[$attr:meta])*
@@ -26,6 +13,8 @@ macro_rules! define_mask {
         pub struct $name<const $lanes: usize>(crate::$type<$lanes2>)
         where
             crate::$type<LANES>: crate::LanesAtMost32;
+
+        impl_full_mask_reductions! { $name, $type }
 
         impl<const LANES: usize> Copy for $name<LANES>
         where
@@ -46,7 +35,6 @@ macro_rules! define_mask {
         where
             crate::$type<LANES>: crate::LanesAtMost32,
         {
-            /// Construct a mask by setting all lanes to the given value.
             pub fn splat(value: bool) -> Self {
                 Self(<crate::$type<LANES>>::splat(
                     if value {
@@ -57,20 +45,12 @@ macro_rules! define_mask {
                 ))
             }
 
-            /// Tests the value of the specified lane.
-            ///
-            /// # Panics
-            /// Panics if `lane` is greater than or equal to the number of lanes in the vector.
             #[inline]
             pub fn test(&self, lane: usize) -> bool {
                 assert!(lane < LANES, "lane index out of range");
                 self.0[lane] == -1
             }
 
-            /// Sets the value of the specified lane.
-            ///
-            /// # Panics
-            /// Panics if `lane` is greater than or equal to the number of lanes in the vector.
             #[inline]
             pub fn set(&mut self, lane: usize, value: bool) {
                 assert!(lane < LANES, "lane index out of range");
@@ -81,55 +61,14 @@ macro_rules! define_mask {
                 }
             }
 
-            /// Converts the mask to the equivalent integer representation, where -1 represents
-            /// "set" and 0 represents "unset".
             #[inline]
             pub fn to_int(self) -> crate::$type<LANES> {
                 self.0
             }
 
-            /// Creates a  mask from the equivalent integer representation, where -1 represents
-            /// "set" and 0 represents "unset".
-            ///
-            /// Each provided lane must be either 0 or -1.
             #[inline]
             pub unsafe fn from_int_unchecked(value: crate::$type<LANES>) -> Self {
                 Self(value)
-            }
-
-            /// Creates a mask from the equivalent integer representation, where -1 represents
-            /// "set" and 0 represents "unset".
-            ///
-            /// # Panics
-            /// Panics if any lane is not 0 or -1.
-            #[inline]
-            pub fn from_int(value: crate::$type<LANES>) -> Self {
-                use core::convert::TryInto;
-                value.try_into().unwrap()
-            }
-        }
-
-        impl<const LANES: usize> core::convert::From<bool> for $name<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            fn from(value: bool) -> Self {
-                Self::splat(value)
-            }
-        }
-
-        impl<const LANES: usize> core::convert::TryFrom<crate::$type<LANES>> for $name<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            type Error = TryFromMaskError;
-            fn try_from(value: crate::$type<LANES>) -> Result<Self, Self::Error> {
-                let valid = (value.lanes_eq(crate::$type::<LANES>::splat(0)) | value.lanes_eq(crate::$type::<LANES>::splat(-1))).all();
-                if valid {
-                    Ok(Self(value))
-                } else {
-                    Err(TryFromMaskError(()))
-                }
             }
         }
 
@@ -139,36 +78,6 @@ macro_rules! define_mask {
         {
             fn from(value: $name<LANES>) -> Self {
                 value.0
-            }
-        }
-
-        impl<const LANES: usize> core::convert::From<crate::BitMask<LANES>> for $name<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-            crate::BitMask<LANES>: crate::LanesAtMost32,
-        {
-            fn from(value: crate::BitMask<LANES>) -> Self {
-                // TODO use an intrinsic to do this efficiently (with LLVM's sext instruction)
-                let mut mask = Self::splat(false);
-                for lane in 0..LANES {
-                    mask.set(lane, value.test(lane));
-                }
-                mask
-            }
-        }
-
-        impl<const LANES: usize> core::convert::From<$name<LANES>> for crate::BitMask<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-            crate::BitMask<LANES>: crate::LanesAtMost32,
-        {
-            fn from(value: $name<$lanes>) -> Self {
-                // TODO use an intrinsic to do this efficiently (with LLVM's trunc instruction)
-                let mut mask = Self::splat(false);
-                for lane in 0..LANES {
-                    mask.set(lane, value.test(lane));
-                }
-                mask
             }
         }
 
@@ -230,28 +139,6 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAnd<bool> for $name<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            type Output = Self;
-            #[inline]
-            fn bitand(self, rhs: bool) -> Self {
-                self & Self::splat(rhs)
-            }
-        }
-
-        impl<const LANES: usize> core::ops::BitAnd<$name<LANES>> for bool
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            type Output = $name<LANES>;
-            #[inline]
-            fn bitand(self, rhs: $name<LANES>) -> $name<LANES> {
-                $name::<LANES>::splat(self) & rhs
-            }
-        }
-
         impl<const LANES: usize> core::ops::BitOr for $name<LANES>
         where
             crate::$type<LANES>: crate::LanesAtMost32,
@@ -263,28 +150,6 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitOr<bool> for $name<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            type Output = Self;
-            #[inline]
-            fn bitor(self, rhs: bool) -> Self {
-                self | Self::splat(rhs)
-            }
-        }
-
-        impl<const LANES: usize> core::ops::BitOr<$name<LANES>> for bool
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            type Output = $name<LANES>;
-            #[inline]
-            fn bitor(self, rhs: $name<LANES>) -> $name<LANES> {
-                $name::<LANES>::splat(self) | rhs
-            }
-        }
-
         impl<const LANES: usize> core::ops::BitXor for $name<LANES>
         where
             crate::$type<LANES>: crate::LanesAtMost32,
@@ -293,28 +158,6 @@ macro_rules! define_mask {
             #[inline]
             fn bitxor(self, rhs: Self) -> Self::Output {
                 Self(self.0 ^ rhs.0)
-            }
-        }
-
-        impl<const LANES: usize> core::ops::BitXor<bool> for $name<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            type Output = Self;
-            #[inline]
-            fn bitxor(self, rhs: bool) -> Self::Output {
-                self ^ Self::splat(rhs)
-            }
-        }
-
-        impl<const LANES: usize> core::ops::BitXor<$name<LANES>> for bool
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            type Output = $name<LANES>;
-            #[inline]
-            fn bitxor(self, rhs: $name<LANES>) -> Self::Output {
-                $name::<LANES>::splat(self) ^ rhs
             }
         }
 
@@ -339,16 +182,6 @@ macro_rules! define_mask {
             }
         }
 
-        impl<const LANES: usize> core::ops::BitAndAssign<bool> for $name<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            #[inline]
-            fn bitand_assign(&mut self, rhs: bool) {
-                *self &= Self::splat(rhs);
-            }
-        }
-
         impl<const LANES: usize> core::ops::BitOrAssign for $name<LANES>
         where
             crate::$type<LANES>: crate::LanesAtMost32,
@@ -356,16 +189,6 @@ macro_rules! define_mask {
             #[inline]
             fn bitor_assign(&mut self, rhs: Self) {
                 self.0 |= rhs.0;
-            }
-        }
-
-        impl<const LANES: usize> core::ops::BitOrAssign<bool> for $name<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            #[inline]
-            fn bitor_assign(&mut self, rhs: bool) {
-                *self |= Self::splat(rhs);
             }
         }
 
@@ -378,47 +201,35 @@ macro_rules! define_mask {
                 self.0 ^= rhs.0;
             }
         }
-
-        impl<const LANES: usize> core::ops::BitXorAssign<bool> for $name<LANES>
-        where
-            crate::$type<LANES>: crate::LanesAtMost32,
-        {
-            #[inline]
-            fn bitxor_assign(&mut self, rhs: bool) {
-                *self ^= Self::splat(rhs);
-            }
-        }
-
-        impl_full_mask_reductions! { $name, $type }
     }
 }
 
 define_mask! {
     /// A mask equivalent to [SimdI8](crate::SimdI8), where all bits in the lane must be either set
     /// or unset.
-    struct SimdMask8<const LANES: usize>(crate::SimdI8<LANES>);
+    struct Mask8<const LANES: usize>(crate::SimdI8<LANES>);
 }
 
 define_mask! {
     /// A mask equivalent to [SimdI16](crate::SimdI16), where all bits in the lane must be either set
     /// or unset.
-    struct SimdMask16<const LANES: usize>(crate::SimdI16<LANES>);
+    struct Mask16<const LANES: usize>(crate::SimdI16<LANES>);
 }
 
 define_mask! {
     /// A mask equivalent to [SimdI32](crate::SimdI32), where all bits in the lane must be either set
     /// or unset.
-    struct SimdMask32<const LANES: usize>(crate::SimdI32<LANES>);
+    struct Mask32<const LANES: usize>(crate::SimdI32<LANES>);
 }
 
 define_mask! {
     /// A mask equivalent to [SimdI64](crate::SimdI64), where all bits in the lane must be either set
     /// or unset.
-    struct SimdMask64<const LANES: usize>(crate::SimdI64<LANES>);
+    struct Mask64<const LANES: usize>(crate::SimdI64<LANES>);
 }
 
 define_mask! {
     /// A mask equivalent to [SimdIsize](crate::SimdIsize), where all bits in the lane must be either set
     /// or unset.
-    struct SimdMaskSize<const LANES: usize>(crate::SimdIsize<LANES>);
+    struct MaskSize<const LANES: usize>(crate::SimdIsize<LANES>);
 }

--- a/crates/core_simd/src/reduction.rs
+++ b/crates/core_simd/src/reduction.rs
@@ -103,18 +103,16 @@ macro_rules! impl_float_reductions {
 }
 
 macro_rules! impl_full_mask_reductions {
-    { $name:ident, $inner:ident } => {
-        impl<const LANES: usize> crate::$name<LANES>
+    { $name:ident, $bits_ty:ident } => {
+        impl<const LANES: usize> $name<LANES>
         where
-            crate::$inner<LANES>: crate::LanesAtMost32
+            crate::$bits_ty<LANES>: crate::LanesAtMost32
         {
-            /// Returns true if any lane is set, or false otherwise.
             #[inline]
             pub fn any(self) -> bool {
                 unsafe { crate::intrinsics::simd_reduce_any(self.to_int()) }
             }
 
-            /// Returns true if all lanes are set, or false otherwise.
             #[inline]
             pub fn all(self) -> bool {
                 unsafe { crate::intrinsics::simd_reduce_all(self.to_int()) }
@@ -124,10 +122,10 @@ macro_rules! impl_full_mask_reductions {
 }
 
 macro_rules! impl_opaque_mask_reductions {
-    { $name:ident, $inner:ident, $bits_ty:ident } => {
+    { $name:ident, $bits_ty:ident } => {
         impl<const LANES: usize> $name<LANES>
         where
-            $bits_ty<LANES>: crate::LanesAtMost32
+            crate::$bits_ty<LANES>: crate::LanesAtMost32
         {
             /// Returns true if any lane is set, or false otherwise.
             #[inline]
@@ -141,22 +139,5 @@ macro_rules! impl_opaque_mask_reductions {
                 self.0.all()
             }
         }
-    }
-}
-
-impl<const LANES: usize> crate::BitMask<LANES>
-where
-    crate::BitMask<LANES>: crate::LanesAtMost32,
-{
-    /// Returns true if any lane is set, or false otherwise.
-    #[inline]
-    pub fn any(self) -> bool {
-        self != Self::splat(false)
-    }
-
-    /// Returns true if all lanes are set, or false otherwise.
-    #[inline]
-    pub fn all(self) -> bool {
-        self == Self::splat(true)
     }
 }

--- a/crates/core_simd/src/reduction.rs
+++ b/crates/core_simd/src/reduction.rs
@@ -104,7 +104,7 @@ macro_rules! impl_float_reductions {
 
 macro_rules! impl_full_mask_reductions {
     { $name:ident, $bits_ty:ident } => {
-        impl<const LANES: usize> $name<LANES>
+        impl<T: crate::Mask, const LANES: usize> $name<T, LANES>
         where
             crate::$bits_ty<LANES>: crate::LanesAtMost32
         {
@@ -125,7 +125,8 @@ macro_rules! impl_opaque_mask_reductions {
     { $name:ident, $bits_ty:ident } => {
         impl<const LANES: usize> $name<LANES>
         where
-            crate::$bits_ty<LANES>: crate::LanesAtMost32
+            crate::$bits_ty<LANES>: crate::LanesAtMost32,
+            $name<LANES>: crate::Mask,
         {
             /// Returns true if any lane is set, or false otherwise.
             #[inline]

--- a/crates/core_simd/src/vector/float.rs
+++ b/crates/core_simd/src/vector/float.rs
@@ -42,6 +42,7 @@ macro_rules! impl_float_vector {
             Self: crate::LanesAtMost32,
             crate::$bits_ty<LANES>: crate::LanesAtMost32,
             crate::$mask_impl_ty<LANES>: crate::LanesAtMost32,
+            crate::$mask_ty<LANES>: crate::Mask,
         {
             /// Returns true for each lane if it has a positive sign, including
             /// `+0.0`, `NaN`s with positive sign bit and positive infinity.

--- a/crates/core_simd/src/vector/int.rs
+++ b/crates/core_simd/src/vector/int.rs
@@ -30,6 +30,7 @@ macro_rules! impl_integer_vector {
         where
             Self: crate::LanesAtMost32,
             crate::$mask_impl_ty<LANES>: crate::LanesAtMost32,
+            crate::$mask_ty<LANES>: crate::Mask,
         {
             /// Returns true for each positive lane and false if it is zero or negative.
             pub fn is_positive(self) -> crate::$mask_ty<LANES> {

--- a/crates/core_simd/src/vector/uint.rs
+++ b/crates/core_simd/src/vector/uint.rs
@@ -1,6 +1,5 @@
 #![allow(non_camel_case_types)]
 
-
 /// Implements additional integer traits (Eq, Ord, Hash) on the specified vector `$name`, holding multiple `$lanes` of `$type`.
 macro_rules! impl_unsigned_vector {
     { $name:ident, $type:ty } => {

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -1,29 +1,8 @@
-use core::convert::TryFrom;
-use core_simd::{BitMask, Mask8, SimdI8, SimdMask8};
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
 #[cfg(target_arch = "wasm32")]
 wasm_bindgen_test_configure!(run_in_browser);
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn mask_format_round_trip() {
-    let ints = SimdI8::from_array([-1, 0, 0, -1]);
-
-    let simd_mask = SimdMask8::try_from(ints).unwrap();
-
-    let bitmask = BitMask::from(simd_mask);
-
-    let opaque_mask = Mask8::from(bitmask);
-
-    let simd_mask_returned = SimdMask8::from(opaque_mask);
-
-    let ints_returned = SimdI8::from(simd_mask_returned);
-
-    assert_eq!(ints_returned, ints);
-}
 
 macro_rules! test_mask_api {
     { $name:ident } => {
@@ -83,6 +62,4 @@ macro_rules! test_mask_api {
 
 mod mask_api {
     test_mask_api! { Mask8 }
-    test_mask_api! { SimdMask8 }
-    test_mask_api! { BitMask }
 }

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -56,6 +56,23 @@ macro_rules! test_mask_api {
                 v.set(2, true);
                 assert!(!v.all());
             }
+
+            #[test]
+            fn roundtrip_int_conversion() {
+                let values = [true, false, false, true, false, false, true, false];
+                let mask = core_simd::$name::<8>::from_array(values);
+                let int = mask.to_int();
+                assert_eq!(int.to_array(), [-1, 0, 0, -1, 0, 0, -1, 0]);
+                assert_eq!(core_simd::$name::<8>::from_int(int), mask);
+            }
+
+            #[test]
+            fn to_bitmask() {
+                use core_simd::ToBitMask;
+                let values = [true, false, false, true, false, false, true, false];
+                let mask = core_simd::$name::<8>::from_array(values);
+                assert_eq!(mask.to_bitmask(), 0b01001001);
+            }
         }
     }
 }

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -68,10 +68,12 @@ macro_rules! test_mask_api {
 
             #[test]
             fn to_bitmask() {
-                use core_simd::ToBitMask;
-                let values = [true, false, false, true, false, false, true, false];
-                let mask = core_simd::$name::<8>::from_array(values);
-                assert_eq!(mask.to_bitmask(), 0b01001001);
+                let values = [
+                    true, false, false, true, false, false, true, false,
+                    false, false, false, false, false, false, false, false,
+                ];
+                let mask = core_simd::$name::<16>::from_array(values);
+                assert_eq!(mask.to_bitmask(), [0b01001001, 0]);
             }
         }
     }

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -70,10 +70,10 @@ macro_rules! test_mask_api {
             fn to_bitmask() {
                 let values = [
                     true, false, false, true, false, false, true, false,
-                    false, false, false, false, false, false, false, false,
+                    true, true, false, false, false, false, false, true,
                 ];
                 let mask = core_simd::$name::<16>::from_array(values);
-                assert_eq!(mask.to_bitmask(), [0b01001001, 0]);
+                assert_eq!(mask.to_bitmask(), [0b01001001, 0b10000011]);
             }
         }
     }

--- a/crates/test_helpers/src/array.rs
+++ b/crates/test_helpers/src/array.rs
@@ -3,13 +3,10 @@
 // Adapted from proptest's array code
 // Copyright 2017 Jason Lingle
 
+use core::{marker::PhantomData, mem::MaybeUninit};
 use proptest::{
     strategy::{NewTree, Strategy, ValueTree},
     test_runner::TestRunner,
-};
-use core::{
-    marker::PhantomData,
-    mem::MaybeUninit,
 };
 
 #[must_use = "strategies do nothing unless used"]

--- a/crates/test_helpers/src/lib.rs
+++ b/crates/test_helpers/src/lib.rs
@@ -281,6 +281,11 @@ macro_rules! test_lanes {
                     core_simd::SimdIsize<$lanes>: core_simd::LanesAtMost32,
                     core_simd::SimdF32<$lanes>: core_simd::LanesAtMost32,
                     core_simd::SimdF64<$lanes>: core_simd::LanesAtMost32,
+                    core_simd::Mask8<$lanes>: core_simd::Mask,
+                    core_simd::Mask16<$lanes>: core_simd::Mask,
+                    core_simd::Mask32<$lanes>: core_simd::Mask,
+                    core_simd::Mask64<$lanes>: core_simd::Mask,
+                    core_simd::MaskSize<$lanes>: core_simd::Mask,
                 $body
 
                 #[cfg(target_arch = "wasm32")]
@@ -350,6 +355,11 @@ macro_rules! test_lanes_panic {
                     core_simd::SimdIsize<$lanes>: core_simd::LanesAtMost32,
                     core_simd::SimdF32<$lanes>: core_simd::LanesAtMost32,
                     core_simd::SimdF64<$lanes>: core_simd::LanesAtMost32,
+                    core_simd::Mask8<$lanes>: core_simd::Mask,
+                    core_simd::Mask16<$lanes>: core_simd::Mask,
+                    core_simd::Mask32<$lanes>: core_simd::Mask,
+                    core_simd::Mask64<$lanes>: core_simd::Mask,
+                    core_simd::MaskSize<$lanes>: core_simd::Mask,
                 $body
 
                 #[test]

--- a/crates/test_helpers/src/lib.rs
+++ b/crates/test_helpers/src/lib.rs
@@ -281,7 +281,6 @@ macro_rules! test_lanes {
                     core_simd::SimdIsize<$lanes>: core_simd::LanesAtMost32,
                     core_simd::SimdF32<$lanes>: core_simd::LanesAtMost32,
                     core_simd::SimdF64<$lanes>: core_simd::LanesAtMost32,
-                    core_simd::BitMask<$lanes>: core_simd::LanesAtMost32,
                 $body
 
                 #[cfg(target_arch = "wasm32")]
@@ -351,7 +350,6 @@ macro_rules! test_lanes_panic {
                     core_simd::SimdIsize<$lanes>: core_simd::LanesAtMost32,
                     core_simd::SimdF32<$lanes>: core_simd::LanesAtMost32,
                     core_simd::SimdF64<$lanes>: core_simd::LanesAtMost32,
-                    core_simd::BitMask<$lanes>: core_simd::LanesAtMost32,
                 $body
 
                 #[test]


### PR DESCRIPTION
Remove explicit bitmasks.

Add `ToBitMask` trait which allows you to convert masks to `u64`.