### PR TITLE
Add SIMD rounding intrinsics

### DIFF
--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -86,6 +86,12 @@ mod std {
 
         // floor
         pub(crate) fn simd_floor<T>(x: T) -> T;
+
+        // round
+        pub(crate) fn simd_round<T>(x: T) -> T;
+
+        // trunc
+        pub(crate) fn simd_trunc<T>(x: T) -> T;
     }
 }
 

--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -43,14 +43,6 @@ extern "platform-intrinsic" {
     /// neg/fneg
     pub(crate) fn simd_neg<T>(x: T) -> T;
 
-    // floor
-    #[cfg(feature = "std")]
-    pub(crate) fn simd_floor<T>(x: T) -> T;
-
-    // ceil
-    #[cfg(feature = "std")]
-    pub(crate) fn simd_ceil<T>(x: T) -> T;
-
     /// fabs
     pub(crate) fn simd_fabs<T>(x: T) -> T;
 
@@ -85,3 +77,17 @@ extern "platform-intrinsic" {
     pub(crate) fn simd_reduce_or<T, U>(x: T) -> U;
     pub(crate) fn simd_reduce_xor<T, U>(x: T) -> U;
 }
+
+#[cfg(feature = "std")]
+mod std {
+    extern "platform-intrinsic" {
+        // ceil
+        pub(crate) fn simd_ceil<T>(x: T) -> T;
+
+        // floor
+        pub(crate) fn simd_floor<T>(x: T) -> T;
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) use crate::intrinsics::std::*;

--- a/crates/core_simd/src/round.rs
+++ b/crates/core_simd/src/round.rs
@@ -2,12 +2,12 @@ macro_rules! implement {
     {
         $type:ident, $int_type:ident
     } => {
+        #[cfg(feature = "std")]
         impl<const LANES: usize> crate::$type<LANES>
         where
             Self: crate::LanesAtMost32,
         {
             /// Returns the largest integer less than or equal to each lane.
-            #[cfg(feature = "std")]
             #[must_use = "method returns a new vector and does not mutate the original value"]
             #[inline]
             pub fn floor(self) -> Self {
@@ -15,7 +15,6 @@ macro_rules! implement {
             }
 
             /// Returns the smallest integer greater than or equal to each lane.
-            #[cfg(feature = "std")]
             #[must_use = "method returns a new vector and does not mutate the original value"]
             #[inline]
             pub fn ceil(self) -> Self {

--- a/crates/core_simd/src/round.rs
+++ b/crates/core_simd/src/round.rs
@@ -7,18 +7,39 @@ macro_rules! implement {
         where
             Self: crate::LanesAtMost32,
         {
-            /// Returns the largest integer less than or equal to each lane.
+            /// Returns the smallest integer greater than or equal to each lane.
+            #[must_use = "method returns a new vector and does not mutate the original value"]
+            #[inline]
+            pub fn ceil(self) -> Self {
+                unsafe { crate::intrinsics::simd_ceil(self) }
+            }
+
+            /// Returns the largest integer value less than or equal to each lane.
             #[must_use = "method returns a new vector and does not mutate the original value"]
             #[inline]
             pub fn floor(self) -> Self {
                 unsafe { crate::intrinsics::simd_floor(self) }
             }
 
-            /// Returns the smallest integer greater than or equal to each lane.
+            /// Rounds to the nearest integer value. Ties round toward zero.
             #[must_use = "method returns a new vector and does not mutate the original value"]
             #[inline]
-            pub fn ceil(self) -> Self {
-                unsafe { crate::intrinsics::simd_ceil(self) }
+            pub fn round(self) -> Self {
+                unsafe { crate::intrinsics::simd_round(self) }
+            }
+
+            /// Returns the floating point's integer value, with its fractional part removed.
+            #[must_use = "method returns a new vector and does not mutate the original value"]
+            #[inline]
+            pub fn trunc(self) -> Self {
+                unsafe { crate::intrinsics::simd_trunc(self) }
+            }
+
+            /// Returns the floating point's fractional value, with its integer part removed.
+            #[must_use = "method returns a new vector and does not mutate the original value"]
+            #[inline]
+            pub fn fract(self) -> Self {
+                self - self.trunc()
             }
         }
 

--- a/crates/core_simd/tests/round.rs
+++ b/crates/core_simd/tests/round.rs
@@ -1,0 +1,66 @@
+macro_rules! float_rounding_test {
+    { $vector:ident, $scalar:tt, $int_scalar:tt } => {
+        mod $scalar {
+            type Vector<const LANES: usize> = core_simd::$vector<LANES>;
+            type Scalar = $scalar;
+            type IntScalar = $int_scalar;
+
+            #[cfg(feature = "std")]
+            test_helpers::test_lanes! {
+                fn ceil<const LANES: usize>() {
+                    test_helpers::test_unary_elementwise(
+                        &Vector::<LANES>::ceil,
+                        &Scalar::ceil,
+                        &|_| true,
+                    )
+                }
+
+                fn floor<const LANES: usize>() {
+                    test_helpers::test_unary_elementwise(
+                        &Vector::<LANES>::floor,
+                        &Scalar::floor,
+                        &|_| true,
+                    )
+                }
+            }
+
+            test_helpers::test_lanes! {
+                fn from_int<const LANES: usize>() {
+                    test_helpers::test_unary_elementwise(
+                        &Vector::<LANES>::round_from_int,
+                        &|x| x as Scalar,
+                        &|_| true,
+                    )
+                }
+
+                fn to_int_unchecked<const LANES: usize>() {
+                    // The maximum integer that can be represented by the equivalently sized float has
+                    // all of the mantissa digits set to 1, pushed up to the MSB.
+                    const ALL_MANTISSA_BITS: IntScalar = ((1 << <Scalar>::MANTISSA_DIGITS) - 1);
+                    const MAX_REPRESENTABLE_VALUE: Scalar =
+                        (ALL_MANTISSA_BITS << (core::mem::size_of::<Scalar>() * 8 - <Scalar>::MANTISSA_DIGITS as usize - 1)) as Scalar;
+
+                    let mut runner = proptest::test_runner::TestRunner::default();
+                    runner.run(
+                        &test_helpers::array::UniformArrayStrategy::new(-MAX_REPRESENTABLE_VALUE..MAX_REPRESENTABLE_VALUE),
+                        |x| {
+                            let result_1 = unsafe { Vector::from_array(x).to_int_unchecked().to_array() };
+                            let result_2 = {
+                                let mut result = [0; LANES];
+                                for (i, o) in x.iter().zip(result.iter_mut()) {
+                                    *o = unsafe { i.to_int_unchecked() };
+                                }
+                                result
+                            };
+                            test_helpers::prop_assert_biteq!(result_1, result_2);
+                            Ok(())
+                        },
+                    ).unwrap();
+                }
+            }
+        }
+    }
+}
+
+float_rounding_test! { SimdF32, f32, i32 }
+float_rounding_test! { SimdF64, f64, i64 }

--- a/crates/core_simd/tests/round.rs
+++ b/crates/core_simd/tests/round.rs
@@ -22,6 +22,30 @@ macro_rules! float_rounding_test {
                         &|_| true,
                     )
                 }
+
+                fn round<const LANES: usize>() {
+                    test_helpers::test_unary_elementwise(
+                        &Vector::<LANES>::round,
+                        &Scalar::round,
+                        &|_| true,
+                    )
+                }
+
+                fn trunc<const LANES: usize>() {
+                    test_helpers::test_unary_elementwise(
+                        &Vector::<LANES>::trunc,
+                        &Scalar::trunc,
+                        &|_| true,
+                    )
+                }
+
+                fn fract<const LANES: usize>() {
+                    test_helpers::test_unary_elementwise(
+                        &Vector::<LANES>::fract,
+                        &Scalar::fract,
+                        &|_| true,
+                    )
+                }
             }
 
             test_helpers::test_lanes! {


### PR DESCRIPTION
Adds SIMD round, trunc, and fract. As part of this, it breaks out rounding intrinsics and tests into their own modules and refactors the code somewhat to use more module- or impl-oriented `#[cfg]`s for the `#[cfg(feature = "std")]` code, because those are easier to manage.