### PR TITLE
Add 32-bit SIMD type aliases i/u16x2 and i/u8x4

### DIFF
--- a/crates/core_simd/src/vector/int.rs
+++ b/crates/core_simd/src/vector/int.rs
@@ -136,6 +136,9 @@ pub type isizex4 = SimdIsize<4>;
 /// Vector of eight `isize` values
 pub type isizex8 = SimdIsize<8>;
 
+/// Vector of two `i16` values
+pub type i16x2 = SimdI16<2>;
+
 /// Vector of four `i16` values
 pub type i16x4 = SimdI16<4>;
 
@@ -168,6 +171,9 @@ pub type i64x4 = SimdI64<4>;
 
 /// Vector of eight `i64` values
 pub type i64x8 = SimdI64<8>;
+
+/// Vector of four `i8` values
+pub type i8x4 = SimdI8<4>;
 
 /// Vector of eight `i8` values
 pub type i8x8 = SimdI8<8>;

--- a/crates/core_simd/src/vector/uint.rs
+++ b/crates/core_simd/src/vector/uint.rs
@@ -105,6 +105,9 @@ pub type usizex4 = SimdUsize<4>;
 /// Vector of eight `usize` values
 pub type usizex8 = SimdUsize<8>;
 
+/// Vector of two `u16` values
+pub type u16x2 = SimdU16<2>;
+
 /// Vector of four `u16` values
 pub type u16x4 = SimdU16<4>;
 
@@ -137,6 +140,9 @@ pub type u64x4 = SimdU64<4>;
 
 /// Vector of eight `u64` values
 pub type u64x8 = SimdU64<8>;
+
+/// Vector of four `u8` values
+pub type u8x4 = SimdU8<4>;
 
 /// Vector of eight `u8` values
 pub type u8x8 = SimdU8<8>;


### PR DESCRIPTION
I've been looking in to SIMD support for the Cortex-M microcontrollers that have the DSP extension (the ARMv7E-M architecture, where E indicates DSP support), where all the DSP operations are on 32-bit packed values of either two 16-bit values or four 8-bit values. The same SIMD instructions are available on ARMv6 (non-M), ARMv7-A/R, ARMv8-A, and ARMv8-M processors too, so they're widely applicable to both application and embedded ARM processors. These are sometimes called "SIMD32" and are distinct from the NEON SIMD instructions.

I noticed stdsimd doesn't currently have any 32-bit types, but as far as I could tell, they only need definitions added like in this PR, and then should generally do the right thing? The relevant intrinsics are in `core::arch::arm::dsp` on nightly, e.g. [i16x2](https://doc.rust-lang.org/nightly/core/arch/arm/dsp/struct.int16x2_t.html). I couldn't spot any reasons to not include these 32-bit values except that presumably there wasn't a use for them previously, but please let me know if this wouldn't work or needs some other changes.

There is one caveat for ARMv7E-M support which is that LLVM does not currently appear to lower to the vector instructions, so the result is correct but not yet optimally computed. Hopefully that can be addressed separately and outside of this crate.

I haven't been able to run `cargo +nightly test` on this because my `rustc 1.55.0-nightly (432e145bd 2021-07-10) running on x86_64-unknown-linux-gnu` gets an ICE when I try, both on master and on this PR branch.